### PR TITLE
Add directory's files to filelist alphanumerically

### DIFF
--- a/src/filelist.h
+++ b/src/filelist.h
@@ -60,6 +60,7 @@ void feh_file_free(feh_file * file);
 feh_file_info *feh_file_info_new(void);
 void feh_file_info_free(feh_file_info * info);
 gib_list *feh_file_rm_and_free(gib_list * list, gib_list * file);
+int file_selector_all(const struct dirent *unused);
 void add_file_to_filelist_recursively(char *origpath, unsigned char level);
 void add_file_to_rm_filelist(char *file);
 void delete_rm_files(void);


### PR DESCRIPTION
Hi,
This commit makes feh add files tot he filelist alphanumerically, rather than by whatever order the filesystem gives.

I am attempting to solve this problem: I want to view pictures in dir_b/ and dir_a/ in that order. Both directories have filenames like 01.jpg 02.jpg, but my filesystem always returns 02.jpg before 01.jpg with readdir(). 

Thanks for your time.
