### PR TITLE
New sort option: mtime

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -532,9 +532,14 @@ in paused mode.
 .It Cm -S , --sort Ar sort_type
 .
 The file list may be sorted according to image parameters.  Allowed sort
-types are: name, filename, width, height, pixels, size, format.  For sort
-modes other than name or filename, a preload run will be necessary,
+types are: name, filename, mtime, width, height, pixels, size, format.  For sort
+modes other than name, filename, or mtime, a preload run will be necessary,
 causing a delay proportional to the number of images in the list.
+.
+.Pp
+.
+The mtime sort mode sorts images by most recently modified. To sort by oldest
+first, reverse the filelist with --reverse.
 .
 .It Cm -| , --start-at Ar filename
 .

--- a/src/filelist.h
+++ b/src/filelist.h
@@ -56,7 +56,7 @@ struct __feh_file_info {
 
 enum filelist_recurse { FILELIST_FIRST, FILELIST_CONTINUE, FILELIST_LAST };
 
-enum sort_type { SORT_NONE, SORT_NAME, SORT_FILENAME, SORT_WIDTH,
+enum sort_type { SORT_NONE, SORT_NAME, SORT_FILENAME, SORT_MTIME, SORT_WIDTH,
 	SORT_HEIGHT,
 	SORT_PIXELS,
 	SORT_SIZE, SORT_FORMAT
@@ -82,6 +82,7 @@ void feh_save_filelist();
 
 int feh_cmp_name(void *file1, void *file2);
 int feh_cmp_filename(void *file1, void *file2);
+int feh_cmp_mtime(void *file1, void *file2);
 int feh_cmp_width(void *file1, void *file2);
 int feh_cmp_height(void *file1, void *file2);
 int feh_cmp_pixels(void *file1, void *file2);

--- a/src/help.raw
+++ b/src/help.raw
@@ -46,7 +46,8 @@ OPTIONS
  -U, --loadable            List all loadable files. No image display
  -u, --unloadable          List all unloadable files. No image display
  -S, --sort SORT_TYPE      Sort files by:
-                           name, filename, width, height, pixels, size or format
+                           name, filename, mtime, width, height, pixels, size,
+                           or format
  -n, --reverse             Reverse sort order
  -A, --action ACTION       Specify action to perform when pressing <return>.
                            Executed by /bin/sh, may contain FORMAT SPECIFIERS

--- a/src/options.c
+++ b/src/options.c
@@ -501,6 +501,8 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 				opt.sort = SORT_NAME;
 			else if (!strcasecmp(optarg, "filename"))
 				opt.sort = SORT_FILENAME;
+			else if (!strcasecmp(optarg, "mtime"))
+				opt.sort = SORT_MTIME;
 			else if (!strcasecmp(optarg, "width"))
 				opt.sort = SORT_WIDTH;
 			else if (!strcasecmp(optarg, "height"))


### PR DESCRIPTION
Sort filelist by modification time, newer files first. Useful for
perusing a directory of images by most recently added or changed.

I had a shell wrapper that pre-sorted the filelist by mtime before
feeding to feh for "tailing" my image directories, so I thought it would
be useful to add this functionality directly to feh.

I did not add any tests, keybindings, or menu actions, but I can if you
like.

Thank you for the awesome software.
