### PR TITLE
update AUTHORS to obscure some email

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,7 +17,7 @@ Mrinal Kalakrishnan <mrinal@india.com>
 Phil Morris (marmot) <marmot@vennercs.com>
     - about.png.
 
-Carlos Puchol <cpg@puchol.com>
+Carlos Puchol - cpg (at) puchol (dot) com
     - configure.in fix for nonstandard imlib2 locations.
 
 Eric Dorland <dorland@lords.com>


### PR DESCRIPTION
[OT: wow, feh is back after all these years! way to go!]

i am proposing to obscure all these emails, because today, putting emails in plain text is just inviting spam.

i would do the same for the rest, but i did not want to over-reach. if you agree, i will happily do it.
