### PR TITLE
Add %L format code (temporary copy of filelist)

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -830,6 +830,10 @@ Image height
 .
 Total number of files in filelist
 .
+.It %L
+.
+Temporary copy of filelist. Multiple uses of %L within the same format string will return the same copy.
+.
 .It %m
 .
 Current mode

--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -467,8 +467,10 @@ char *feh_printf(char *str, feh_file * file, winwidget winwid)
 	char *c;
 	char buf[20];
 	static char ret[4096];
+	char *filelist_tmppath;
 
 	ret[0] = '\0';
+	filelist_tmppath = NULL;
 
 	for (c = str; *c != '\0'; c++) {
 		if ((*c == '%') && (*(c+1) != '\0')) {
@@ -491,6 +493,15 @@ char *feh_printf(char *str, feh_file * file, winwidget winwid)
 			case 'l':
 				snprintf(buf, sizeof(buf), "%d", gib_list_length(filelist));
 				strcat(ret, buf);
+				break;
+			case 'L':
+				if (filelist_tmppath != NULL) {
+					strcat(ret, filelist_tmppath);
+				} else {
+					filelist_tmppath = feh_unique_filename("/tmp/","filelist");
+					feh_write_filelist(filelist, filelist_tmppath);
+					strcat(ret, filelist_tmppath);
+				}
 				break;
 			case 'm':
 				strcat(ret, mode);
@@ -589,6 +600,8 @@ char *feh_printf(char *str, feh_file * file, winwidget winwid)
 		} else
 			strncat(ret, c, 1);
 	}
+	if (filelist_tmppath != NULL)
+		free(filelist_tmppath);
 	return(ret);
 }
 


### PR DESCRIPTION
The most salient use is cloning a feh session. See issue #128 for more information.

This turns out to have been very straightforward to implement.

As I indicated in the issue (issue #128), copies of the filelist are reused within a given command (so the two instances of %L within the action "echo %L %L" evaluate to the same string for a given invocation, but what %L evaluates to will change between invocations..). This is what I regard as the least surprising behaviour.
