### PR TITLE
Fix for segfault due to erroneous free() in case of scandir error Failed scan directory

### DIFF
--- a/src/filelist.c
+++ b/src/filelist.c
@@ -263,27 +263,27 @@ void add_file_to_filelist_recursively(char *origpath, unsigned char level)
 			default:
 				weprintf("Failed to scan directory %s:", path);
 			}
-		}
+		} else {
+			for (cnt = 0; cnt < n; cnt++) {
+				if (strcmp(de[cnt]->d_name, ".")
+						&& strcmp(de[cnt]->d_name, "..")) {
+					char *newfile;
 
-		for (cnt = 0; cnt < n; cnt++) {
-			if (strcmp(de[cnt]->d_name, ".")
-					&& strcmp(de[cnt]->d_name, "..")) {
-				char *newfile;
+					newfile = estrjoin("", path, "/", de[cnt]->d_name, NULL);
 
-				newfile = estrjoin("", path, "/", de[cnt]->d_name, NULL);
+					/* This ensures we go down one level even if not fully recursive
+					   - this way "feh some_dir" expands to some_dir's contents */
+					if (opt.recursive)
+						add_file_to_filelist_recursively(newfile, FILELIST_CONTINUE);
+					else
+						add_file_to_filelist_recursively(newfile, FILELIST_LAST);
 
-				/* This ensures we go down one level even if not fully recursive
-				   - this way "feh some_dir" expands to some_dir's contents */
-				if (opt.recursive)
-					add_file_to_filelist_recursively(newfile, FILELIST_CONTINUE);
-				else
-					add_file_to_filelist_recursively(newfile, FILELIST_LAST);
-
-				free(newfile);
+					free(newfile);
+				}
+				free(de[cnt]);
 			}
-			free(de[cnt]);
+			free(de);
 		}
-		free(de);
 		closedir(dir);
 	} else if (S_ISREG(st.st_mode)) {
 		D(("Adding regular file %s to filelist\n", path));


### PR DESCRIPTION
Hello,

I've run into this:

feh -FZYzrD 3 photos/
feh WARNING: Failed to scan directory phoenixPhoto/#recycle: Permission denied
**\* Error in `/home/vorburger/dev/git/feh/src/feh': double free or corruption (out): 0x00007fffffffe200 ***

and found that this is because it does free() even when scandir failed, which it shouldn't. With this fix, above doesn't happen anymore.

Please carefully review my diff to ensure I'm not screwing anything up, or rewrite it... this little fun with gdb to pinpoint this and fix is my first C in almost 13 years... ;-) Now quickly back to my usual Java land, which has GC and clear NullPointerException, instead of malloc/free & Co! :-)

Thank you for feh.

Regards,
Michael
