### PR TITLE
Add shebang and set executable bit on ~/.fehbg

### DIFF
--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -456,7 +456,7 @@ void feh_wm_set_bg(char *fil, Imlib_Image im, int centered, int scaled,
 				if ((fp = fopen(path, "w")) == NULL) {
 					weprintf("Can't write to %s", path);
 				} else {
-					fprintf(fp, "#!/bin/bash\n%s\n", fehbg);
+					fprintf(fp, "#!/bin/sh\n%s\n", fehbg);
 					fclose(fp);
 					stat(path, &s);
 					if (chmod(path, s.st_mode | S_IXUSR | S_IXGRP) != 0) {


### PR DESCRIPTION
Before, feh would output this file to `~/.fehbg`:

```
sircmpwn@sayaka ~/s/feh master> cat ~/.fehbg
feh  --bg-fill '/home/sircmpwn/wallpaper.png' 
sircmpwn@sayaka ~/s/feh master> ls -l ~/.fehbg 
-rw-r--r-- 1 sircmpwn sircmpwn 47 Aug 21 11:22 /home/sircmpwn/.fehbg
```

With this patch applied, it instead does this:

```
sircmpwn@sayaka ~/s/feh master> cat ~/.fehbg
#!/bin/sh
feh  --bg-fill '/home/sircmpwn/wallpaper.png' 
sircmpwn@sayaka ~/s/feh master> ls -l ~/.fehbg 
-rwxr-xr-- 1 sircmpwn sircmpwn 59 Aug 21 11:23 /home/sircmpwn/.fehbg*
```
