### PR TITLE
Support Background Setter for a Single Display

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -470,6 +470,13 @@ managers.
 Disable Xinerama support.  Only makes sense when you have Xinerama support
 compiled in.
 .
+.It Cm --xinerama-index
+.
+Force Xinerama screen index to use.  Only makes sense when you have 
+Xinerama support compiled in and using
+.Nm
+as a background setter.
+.
 .It Cm -j , --output-dir Ar directory
 .
 Save files to
@@ -820,7 +827,12 @@ on screen 0, the second on screen 1, and so on.
 .
 Use
 .Cm --no-xinerama
-to treat the whole X display as one screen when setting wallpapers.
+to treat the whole X display as one screen when setting wallpapers. You
+may also use
+.Cm --xinerama-index
+to use
+.Nm
+as a background setter for a specific screen.
 .
 .Bl -tag -width indent
 .

--- a/src/options.c
+++ b/src/options.c
@@ -71,6 +71,7 @@ void init_parse_options(int argc, char **argv)
 	/* if we're using xinerama, then enable it by default */
 	opt.xinerama = 1;
 #endif				/* HAVE_LIBXINERAMA */
+	opt.xinerama_index = -1;
 
 	feh_getopt_theme(argc, argv);
 
@@ -404,6 +405,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		{"no-fehbg"      , 0, 0, 236},
 		{"keep-zoom-vp"  , 0, 0, 237},
 		{"scroll-step"   , 1, 0, 238},
+		{"xinerama-index", 1, 0, 239},
 
 		{0, 0, 0, 0}
 	};
@@ -743,6 +745,9 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 			break;
 		case 238:
 			opt.scroll_step = atoi(optarg);
+			break;
+		case 239:
+			opt.xinerama_index = atoi(optarg);
 			break;
 		default:
 			break;

--- a/src/options.h
+++ b/src/options.h
@@ -109,6 +109,7 @@ struct __fehoptions {
 	int default_zoom;
 	int zoom_mode;
 	unsigned char adjust_reload;
+	int xinerama_index;
 
 	/* signed in case someone wants to invert scrolling real quick */
 	int scroll_step;

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -465,8 +465,9 @@ void feh_wm_set_bg(char *fil, Imlib_Image im, int centered, int scaled,
 				}
 				free(path);
 			}
-			free(fehbg);
 		}
+		
+		if (fehbg) free(fehbg);
 
 		/* create new display, copy pixmap to new display */
 		disp2 = XOpenDisplay(NULL);


### PR DESCRIPTION
The following code is used to render a background image for a single X head. Had a system where two heads were being overlapped on multiple displays. I wanted to be able to have `feh` set the background for either A or B (depending on the user's preference).

```
|---------------------|
|      A     |        |
|------------|    B   |
|                     |
|---------------------|
```

From this, a user could configure (for example) on area A by invoking the following:
> feh image.png --bg-scale --xinerama-index 0