### PR TITLE
events: also react to ConfigureNotify after mapping

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -41,7 +41,6 @@ feh_event_handler *ev_handler[LASTEvent];
 
 static void feh_event_handle_ButtonPress(XEvent * ev);
 static void feh_event_handle_ButtonRelease(XEvent * ev);
-static void feh_event_handle_ConfigureNotify(XEvent * ev);
 static void feh_event_handle_LeaveNotify(XEvent * ev);
 static void feh_event_handle_MotionNotify(XEvent * ev);
 static void feh_event_handle_ClientMessage(XEvent * ev);
@@ -416,7 +415,7 @@ static void feh_event_handle_ButtonRelease(XEvent * ev)
 	return;
 }
 
-static void feh_event_handle_ConfigureNotify(XEvent * ev)
+void feh_event_handle_ConfigureNotify(XEvent * ev)
 {
 	while (XCheckTypedWindowEvent(disp, ev->xconfigure.window, ConfigureNotify, ev));
 	if (!menu_root) {

--- a/src/events.h
+++ b/src/events.h
@@ -32,4 +32,6 @@ extern feh_event_handler *ev_handler[];
 
 void feh_event_init(void);
 
+void feh_event_handle_ConfigureNotify(XEvent * ev);
+
 #endif

--- a/src/keyevents.c
+++ b/src/keyevents.c
@@ -612,14 +612,8 @@ void feh_event_handle_keypress(XEvent * ev)
 	}
 	else if (feh_is_kp(&keys.zoom_default, keysym, state)) {
 		winwid->zoom = 1.0;
-		/* --scale-down will revert our operation if old_zoom == 1.0 */
-		if (opt.scale_down)
-			winwid->old_zoom = 1.001;
 		winwidget_center_image(winwid);
 		winwidget_render_image(winwid, 0, 0);
-		/* --scale-down will also do weird stuff if zoom is 1.0 */
-		if (opt.scale_down)
-			winwid->zoom = 1.001;
 	}
 	else if (feh_is_kp(&keys.zoom_fit, keysym, state)) {
 		feh_calc_needed_zoom(&winwid->zoom, winwid->im_w, winwid->im_h, winwid->w, winwid->h);

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -28,6 +28,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "filelist.h"
 #include "winwidget.h"
 #include "options.h"
+#include "events.h"
 
 static void winwidget_unregister(winwidget win);
 static void winwidget_register(winwidget win);
@@ -776,6 +777,15 @@ void winwidget_show(winwidget winwid)
 		/* wait for the window to map */
 		D(("Waiting for window to map\n"));
 		XMaskEvent(disp, StructureNotifyMask, &ev);
+		/* Unfortunately, StructureNotifyMask does not only mask
+		 * the events of type MapNotify (which we want to mask here)
+		 * but also such of type ConfigureNotify (and others, see
+		 * https://tronche.com/gui/x/xlib/events/processing-overview.html),
+		 * which should be handled, especially on tiling wm's. To
+		 * remedy this, the handler is executed explicitly:
+		 */
+		if (ev.type == ConfigureNotify)
+			feh_event_handle_ConfigureNotify(&ev);
 		D(("Window mapped\n"));
 		winwid->visible = 1;
 	}

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -298,6 +298,11 @@ void winwidget_create_window(winwidget ret, int w, int h)
 	XSetCommand(disp, ret->win, cmdargv, cmdargc);
 
 	winwidget_register(ret);
+	if (opt.scale_down) {
+		opt.geom_w = w;
+		opt.geom_h = h;
+		opt.geom_flags |= WidthValue | HeightValue;
+	}
 	return;
 }
 
@@ -409,28 +414,6 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 
 	winwidget_setup_pixmaps(winwid);
 
-	if (!winwid->full_screen && opt.scale_down &&
-							  (winwid->type != WIN_TYPE_THUMBNAIL) &&
-							  (winwid->old_zoom == 1.0)) {
-        int max_w = winwid->w, max_h = winwid->h;
-        if (opt.geom_flags & WidthValue) {
-            max_w = opt.geom_w;
-        }
-        if (opt.geom_flags & HeightValue) {
-            max_h = opt.geom_h;
-        }
-        D(("max: %dx%d, size: %dx%d\n", max_w, max_h, winwid->im_w, winwid->im_h));
-        if (max_w < winwid->im_w || max_h < winwid->im_h) {
-            D(("scaling down image %dx%d\n", max_w, max_h));
-
-            feh_calc_needed_zoom(&(winwid->zoom), winwid->im_w, winwid->im_h,
-                    max_w, max_h);
-            if (resize)
-                winwidget_resize(winwid, winwid->im_w * winwid->zoom, winwid->im_h * winwid->zoom);
-            D(("after scaling down image %dx%d\n", winwid->w, winwid->h));
-        }
-	}
-
 	if (!winwid->full_screen && ((gib_imlib_image_has_alpha(winwid->im))
 				     || (opt.geom_flags & (WidthValue | HeightValue))
 				     || (winwid->im_x || winwid->im_y) || (winwid->zoom != 1.0)
@@ -445,7 +428,7 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 
 
 	if (resize && (winwid->full_screen
-                     || (!opt.scale_down && (opt.geom_flags & (WidthValue | HeightValue))))) {
+                     || (opt.geom_flags & (WidthValue | HeightValue)))) {
 		int smaller;	/* Is the image smaller than screen? */
 		int max_w = 0, max_h = 0;
 
@@ -533,7 +516,7 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 			winwid->im_y = (int) (max_h - (winwid->im_h * winwid->zoom)) >> 1;
 		}
 	}
-	else if (need_center && !winwid->full_screen && opt.scale_down
+	else if (need_center && !winwid->full_screen
 			&& (winwid->type != WIN_TYPE_THUMBNAIL)) {
 		winwid->im_x = (int) (winwid->w - (winwid->im_w * winwid->zoom)) >> 1;
 		winwid->im_y = (int) (winwid->h - (winwid->im_h * winwid->zoom)) >> 1;
@@ -848,7 +831,7 @@ void winwidget_resize(winwidget winwid, int w, int h)
 	D(("   x %d y %d w %d h %d\n", attributes.x, attributes.y, winwid->w,
 		winwid->h));
 
-    if (!opt.scale_down && opt.geom_flags & (WidthValue | HeightValue)) {
+    if (opt.geom_flags & (WidthValue | HeightValue)) {
         winwid->had_resize = 1;
         return;
     }


### PR DESCRIPTION
This should help clean the --scale-down "mess" #81 by ensuring that `feh` after mapping its window correctly knows its current window size.

I have only tested this in `ratpoison` where the `ConfigureNotify` event seems to always precede the `MapNotify`, resulting in incorrect rendering of the first image of any slideshow. Behaviour on other WM's is not tested, feel free to comment if this change does not work for yours!

I have some more things coming to avoid the double-rendering / flicker as discussed in #54, but I'm not completely happy with those changes.