### PR TITLE
Allow HTTPS connections with self-signed certs, plus an include fix/trailing whitespace removal

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -392,6 +392,12 @@ with
 .Qq Nm
 in the name.
 .
+.It Cm --insecure
+.
+When viewing files with HTTPS, this option disables strict hostname and peer
+checking. This allows images on sites with self-signed certificates to be
+opened, but is no more secure than plain HTTP.
+.
 .It Cm --keep-zoom-vp
 .
 When switching images, keep zoom and viewport settings

--- a/src/help.raw
+++ b/src/help.raw
@@ -38,6 +38,7 @@ OPTIONS
      --cycle-once          Exit after one loop through the slideshow
  -R, --reload NUM          Reload images after NUM seconds
  -k, --keep-http           Keep local copies when viewing HTTP/FTP files
+     --insecure            Disable peer/host verification when using HTTPS.
  -K, --caption-path PATH   Path to caption directory, enables caption display
  -j, --output-dir          With -k: Output directory for saved files
  -l, --list                list mode: ls-style output with image information

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -394,7 +394,7 @@ static char *feh_http_load_image(char *url)
 
 	if (strlen(tmpname) > (NAME_MAX-6))
 		tmpname[NAME_MAX-7] = '\0';
-	
+
 	sfn = estrjoin("_", tmpname, "XXXXXX", NULL);
 	free(tmpname);
 
@@ -411,6 +411,10 @@ static char *feh_http_load_image(char *url)
 			curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, ebuff);
 			curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
 			curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
+			if (opt.insecure_ssl) {
+				curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+				curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
+			}
 
 			res = curl_easy_perform(curl);
 			curl_easy_cleanup(curl);
@@ -631,7 +635,7 @@ void feh_draw_filename(winwidget w)
 	return;
 }
 
-#ifdef HAVE_LIBEXIF  
+#ifdef HAVE_LIBEXIF
 void feh_draw_exif(winwidget w)
 {
 	static Imlib_Font fn = NULL;
@@ -656,13 +660,13 @@ void feh_draw_exif(winwidget w)
 
 	fn = feh_load_font(w);
 
-	if (buffer == NULL) 
+	if (buffer == NULL)
 	{
 		snprintf(buffer, EXIF_MAX_DATA, "%s", estrdup("Failed to run exif command"));
 		gib_imlib_get_text_size(fn, &buffer[0], NULL, &width, &height, IMLIB_TEXT_TO_RIGHT);
 		no_lines = 1;
 	}
-	else 
+	else
 	{
 
 		while ( (no_lines < 128) && (pos < EXIF_MAX_DATA) )
@@ -688,9 +692,9 @@ void feh_draw_exif(winwidget w)
 			    pos++;
 			    break;
 			  }
-			        
+
 			   pos++;
-			   pos2++;  
+			   pos2++;
 			}
 
 			gib_imlib_get_text_size(fn, info_line, NULL, &line_width,
@@ -720,7 +724,7 @@ void feh_draw_exif(winwidget w)
 
 	feh_imlib_image_fill_text_bg(im, width, height);
 
-	for (i = 0; i < no_lines; i++) 
+	for (i = 0; i < no_lines; i++)
 	{
 		gib_imlib_text_draw(im, fn, NULL, 2, (i * line_height) + 2,
 				info_buf[i], IMLIB_TEXT_TO_RIGHT, 0, 0, 0, 255);

--- a/src/options.c
+++ b/src/options.c
@@ -406,7 +406,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		{"keep-zoom-vp"  , 0, 0, 237},
 		{"scroll-step"   , 1, 0, 238},
 		{"xinerama-index", 1, 0, 239},
-
+		{"insecure"      , 0, 0, 240},
 		{0, 0, 0, 0}
 	};
 	int optch = 0, cmdx = 0;
@@ -759,6 +759,8 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		case 239:
 			opt.xinerama_index = atoi(optarg);
 			break;
+		case 240:
+			opt.insecure_ssl = 1;
 		default:
 			break;
 		}
@@ -863,7 +865,7 @@ static void show_usage(void)
 {
 	fputs(
 #ifdef INCLUDE_HELP
-#include "help.inc"
+#include "help.raw"
 #else
 	"See 'man " PACKAGE "'\n"
 #endif

--- a/src/options.h
+++ b/src/options.h
@@ -73,6 +73,7 @@ struct __fehoptions {
 	unsigned char image_bg;
 	unsigned char no_fehbg;
 	unsigned char keep_zoom_vp;
+	unsigned char insecure_ssl;
 
 	char *output_file;
 	char *output_dir;


### PR DESCRIPTION
Changes:

* Added an `--insecure` option to disable host/peer verification in libcurl.
This allows `feh` to load images on HTTPS hosts with self-signed certificates.
For security, this is not the default.
* Fixed an include in `show_usage`.
* Removed some trailing whitespace.