### PR TITLE
src/main.c: Clean up the Display variable upon exiting

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -196,6 +196,9 @@ void feh_clean_exit(void)
 	free(opt.menu_bg);
 	free(opt.menu_font);
 
+    if(disp)
+        XCloseDisplay(disp);
+
 	if (opt.filelistfile)
 		feh_write_filelist(filelist, opt.filelistfile);
 


### PR DESCRIPTION
XCloseDisplay never gets called for `disp` so it is still around when the program is exiting.