### PR TITLE
src/main.c: free the malloc'ed sections of the options

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -193,6 +193,9 @@ void feh_clean_exit(void)
 {
 	delete_rm_files();
 
+	free(opt.menu_bg);
+	free(opt.menu_font);
+
 	if (opt.filelistfile)
 		feh_write_filelist(filelist, opt.filelistfile);
 


### PR DESCRIPTION
These two sections get malloc'ed when reading the options but never free'd. I put them in the cleanup method to make sure they aren't free'd before needed. 