### PR TITLE
src/main.c: switch spaces to tabs to clobber GCC warning

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -196,8 +196,8 @@ void feh_clean_exit(void)
 	free(opt.menu_bg);
 	free(opt.menu_font);
 
-    if(disp)
-        XCloseDisplay(disp);
+	if(disp)
+		XCloseDisplay(disp);
 
 	if (opt.filelistfile)
 		feh_write_filelist(filelist, opt.filelistfile);


### PR DESCRIPTION
One of my previous changes introduced the fix below but I used spaces and not tabs to do this. The new version of GCC complains about misleading indentation so I feel compelled to fix this warning.