### PR TITLE
Add optional Docker-based build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:jessie
+
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        gcc \
+        libjpeg-turbo-progs \
+        imagemagick \
+        libX11-dev \
+        libxinerama-dev \
+        libimlib2-dev \
+        libcurl4-openssl-dev \
+        libxt-dev \
+        giblib-dev \
+        git
+COPY . /src
+WORKDIR /src
+CMD ["make"]

--- a/README
+++ b/README
@@ -83,3 +83,17 @@ $ make test-x11
 
 Be aware that this is quite experimental, so far the X-tests have only been
 run on one machine. So they may or may not work for you.
+
+Docker Build
+------------
+
+feh includes a Dockerfile which will install all of the dependencies for
+compiling feh in a Docker image if desired.
+
+To build feh inside of Docker, you can use the following commands:
+
+$ docker build -t feh .
+$ docker run feh
+
+Then feh can be installed on your local system with the usual "sudo make
+install".


### PR DESCRIPTION
@derf 

If you're interested, I've been using this `Dockerfile` to compile `feh` inside of Docker.  It could probably be extended to be able to run the tests and stuff as well, but this gets the basic compile working.

Signed-off-by: Nathan LeClaire nathan.leclaire@gmail.com
