### PR TITLE
added --begin-top option to force view point at the top of the image

### DIFF
--- a/src/help.raw
+++ b/src/help.raw
@@ -24,6 +24,7 @@ OPTIONS
                            before attempting to display anything
  -., --scale-down          Automatically scale down images to fit screen size
  -F, --fullscreen          Make the window full screen
+     --begin-top           Force view point at the top of the image
  -Z, --auto-zoom           Zoom picture to screen size in fullscreen/geom mode
      --zoom PERCENT        Zooms images by a PERCENT, when in full screen
                            mode or when window geometry is fixed. If combined

--- a/src/options.c
+++ b/src/options.c
@@ -409,6 +409,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		{"xinerama-index", 1, 0, 239},
 		{"insecure"      , 0, 0, 240},
 		{"no-recursive"  , 0, 0, 241},
+		{"begin-top"      , 0, 0, 242},
 		{0, 0, 0, 0}
 	};
 	int optch = 0, cmdx = 0;
@@ -770,6 +771,9 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 			opt.insecure_ssl = 1;
 		case 241:
 			opt.recursive = 0;
+		case 242:
+			opt.begin_top = 1;
+			break;
 		default:
 			break;
 		}

--- a/src/options.h
+++ b/src/options.h
@@ -111,6 +111,7 @@ struct __fehoptions {
 	unsigned int geom_h;
 	int default_zoom;
 	int zoom_mode;
+	int begin_top;
 	unsigned char adjust_reload;
 	int xinerama_index;
 

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -432,10 +432,12 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 	int antialias = 0;
 	int need_center = winwid->had_resize;
 
+	/* Causes horrible "tearing" (render picture big/small if auto-zoom is on),
+	 * if you switch fast between images (slideshow).
 	if (!winwid->full_screen && resize) {
 		winwidget_resize(winwid, winwid->im_w, winwid->im_h, 0);
 		winwidget_reset_image(winwid);
-	}
+	}*/
 
 	/* bounds checks for panning */
 	if (winwid->im_x > winwid->w)
@@ -563,6 +565,9 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 			&& (winwid->type != WIN_TYPE_THUMBNAIL) && !opt.keep_zoom_vp) {
 		winwid->im_x = (int) (winwid->w - (winwid->im_w * winwid->zoom)) >> 1;
 		winwid->im_y = (int) (winwid->h - (winwid->im_h * winwid->zoom)) >> 1;
+
+		if (opt.begin_top)
+			winwid->im_y = 0;
 	}
 
 	/* Now we ensure only to render the area we're looking at */


### PR DESCRIPTION
Feh automatically shows the centre of the image after zooming into the image. This option forces feh to set the view point after zooming at the top.I also comment out one if-else case that causes extreme fast switching between the same image (first big then small, if auto-zoom is on in sideshow and the user skips between images).