### PR TITLE
Fix double-free/OOB-write while receiving IPC data

### DIFF
--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -795,7 +795,7 @@ char *enl_ipc_get(const char *msg_data)
 {
 
 	static char *message = NULL;
-	static unsigned short len = 0;
+	static size_t len = 0;
 	char buff[13], *ret_msg = NULL;
 	register unsigned char i;
 	unsigned char blen;


### PR DESCRIPTION
If a malicious client pretends to be the E17 window manager, it is
possible to trigger an out of boundary heap write while receiving an
IPC message.

The length of the already received message is stored in an unsigned
short, which overflows after receiving 64 KB of data. It's comparably
small amount of data and therefore achievable for an attacker.

When len overflows, realloc() will either be called with a small value
and therefore chars will be appended out of bounds, or len + 1 will be
exactly 0, in which case realloc() behaves like free(). This could be
abused for a later double-free attack as it's even possible to overwrite
the free information -- but this depends on the malloc implementation.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>