### PR TITLE
Avoid out of boundary read on empty/broken file.

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -183,14 +183,14 @@ char *ereadfile(char *path)
 {
 	char buffer[4096];
 	FILE *fp;
-	int count;
+	size_t count;
 
 	fp = fopen(path, "r");
 	if (!fp)
 		return NULL;
 
 	count = fread(buffer, sizeof(char), sizeof(buffer) - 1, fp);
-	if (buffer[count - 1] == '\n')
+	if (count > 0 && buffer[count - 1] == '\n')
 		buffer[count - 1] = '\0';
 	else
 		buffer[count] = '\0';


### PR DESCRIPTION
If ereadfile encounters an empty file or the file could not be read, an
out ouf boundary read (and possible write) occurs. Always check the
return value of fread to be > 0 before processing the result buffer.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>