### PR TITLE
Always terminate strncpy results with '\0'.

### DIFF
--- a/src/collage.c
+++ b/src/collage.c
@@ -191,8 +191,10 @@ void init_collage_mode(void)
 		char output_buf[1024];
 		if (opt.output_dir)
 			snprintf(output_buf, 1024, "%s/%s", opt.output_dir, opt.output_file);
-		else
-			strncpy(output_buf, opt.output_file, 1024);
+		else {
+			strncpy(output_buf, opt.output_file, 1023);
+			output_buf[1023] = '\0';
+		}
 		gib_imlib_save_image(im_main, output_buf);
 		if (opt.verbose) {
 			int tw, th;

--- a/src/index.c
+++ b/src/index.c
@@ -324,8 +324,10 @@ void init_index_mode(void)
 
 		if (opt.output_dir)
 			snprintf(output_buf, 1024, "%s/%s", opt.output_dir, opt.output_file);
-		else
-			strncpy(output_buf, opt.output_file, 1024);
+		else {
+			strncpy(output_buf, opt.output_file, 1023);
+			output_buf[1023] = '\0';
+		}
 
 		gib_imlib_save_image_with_error_return(im_main, output_buf, &err);
 		if (err) {

--- a/src/thumbnail.c
+++ b/src/thumbnail.c
@@ -381,8 +381,10 @@ void init_thumbnail_mode(void)
 
 		if (opt.output_dir)
 			snprintf(output_buf, 1024, "%s/%s", opt.output_dir, opt.output_file);
-		else
-			strncpy(output_buf, opt.output_file, 1024);
+		else {
+			strncpy(output_buf, opt.output_file, 1023);
+			output_buf[1023] = '\0';
+		}
 		gib_imlib_save_image_with_error_return(td.im_main, output_buf, &err);
 		if (err) {
 			feh_imlib_print_load_error(output_buf, td.im_main, err);


### PR DESCRIPTION
The strncpy function does not guarantee to end the resulting character
sequence with a terminating nul character if not enough space is
available. This could be triggered by supplying a sufficiently long
output_file option.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>