### PR TITLE
Fixed memory leak on file name collision.

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -169,9 +169,11 @@ char *feh_unique_filename(char *path, char *basename)
 	ppid = getpid();
 	snprintf(cppid, sizeof(cppid), "%06ld", (long) ppid);
 
+	tmpname = NULL;
 	/* make sure file doesn't exist */
 	do {
 		snprintf(num, sizeof(num), "%06ld", i++);
+		free(tmpname);
 		tmpname = estrjoin("", path, "feh_", cppid, "_", num, "_", basename, NULL);
 	}
 	while (stat(tmpname, &st) == 0);


### PR DESCRIPTION
If feh_unique_filename encounters a file that already exists, the memory
for the temporary filename is not released. As this happens in /tmp at
some code places, an attacker could use this to spray the memory of feh,
or simply triggering an out of memory condition.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>