### PR TITLE
Check malloc return value for NULL.

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -122,7 +122,7 @@ char *estrjoin(const char *separator, ...)
 			s = va_arg(args, char *);
 		}
 		va_end(args);
-		string = malloc(sizeof(char) * (len + 1));
+		string = _emalloc(sizeof(char) * (len + 1));
 
 		*string = 0;
 		va_start(args, separator);


### PR DESCRIPTION
If malloc cannot allocate enough memory, it could return NULL. This is
not necessarily true for default Linux settings, but can be provoked
there as well by adjusting proc entries. Other systems like the *BSD
ones definitely do this.

The function _emalloc exists for exactly this purpose, so use it instead
of calling malloc directly.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>