### PR TITLE
Use XDG folders for thumbnails.

### DIFF
--- a/src/feh_png.c
+++ b/src/feh_png.c
@@ -94,7 +94,7 @@ gib_hash *feh_png_read_comments(char *file)
 }
 
 /* grab image data from image and write info file with comments ... */
-int feh_png_write_png(Imlib_Image image, char *file, ...)
+int feh_png_write_png_fd(Imlib_Image image, int fd, ...)
 {
 	FILE *fp;
 	int i, w, h;
@@ -111,7 +111,7 @@ int feh_png_write_png(Imlib_Image image, char *file, ...)
 	char *pair_key, *pair_text;
 #endif				/* PNG_TEXT_SUPPORTED */
 
-	if (!(fp = fopen(file, "wb")))
+	if (!(fp = fdopen(fd, "wb")))
 		return 0;
 
 	png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
@@ -155,7 +155,7 @@ int feh_png_write_png(Imlib_Image image, char *file, ...)
 	png_set_sBIT(png_ptr, info_ptr, &sig_bit);
 
 #ifdef PNG_TEXT_SUPPORTED
-	va_start(args, file);
+	va_start(args, fd);
 	for (i = 0; i < FEH_PNG_NUM_COMMENTS; i++) {
 		if ((pair_key = va_arg(args, char *))
 		    && (pair_text = va_arg(args, char *))) {

--- a/src/feh_png.h
+++ b/src/feh_png.h
@@ -32,7 +32,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <stdarg.h>
 
 gib_hash *feh_png_read_comments(char *file);
-int feh_png_write_png(Imlib_Image image, char *file, ...);
+int feh_png_write_png_fd(Imlib_Image image, int fd, ...);
 
 int feh_png_file_is_png(FILE * fp);
 

--- a/src/thumbnail.c
+++ b/src/thumbnail.c
@@ -657,7 +657,7 @@ char *feh_thumbnail_get_name_md5(char *uri)
 	md5_finish(&pms, digest);
 
 	/* print the md5 as hex to a string */
-	md5_name = emalloc(32 + 4 + 1 * sizeof(char));	/* md5 + .png + '\0' */
+	md5_name = emalloc(32 + 4 + 1);	/* md5 + .png + '\0' */
 	for (i = 0, pos = md5_name; i < 16; i++, pos += 2) {
 		sprintf(pos, "%02x", digest[i]);
 	}

--- a/src/thumbnail.c
+++ b/src/thumbnail.c
@@ -586,7 +586,7 @@ static char *feh_thumbnail_get_prefix()
 {
 	char *dir = NULL, *home, *xdg_cache_home;
 
-        // TODO: perhaps make sure that either of those paths aren't /-terminated
+	// TODO: perhaps make sure that either of those paths aren't /-terminated
 
 	xdg_cache_home = getenv("XDG_CACHE_HOME");
 	if (xdg_cache_home && xdg_cache_home[0] == '/') {
@@ -607,12 +607,12 @@ char *feh_thumbnail_get_name(char *uri)
 
 	/* FIXME: make sure original file isn't under ~/.thumbnails */
 
-        prefix = feh_thumbnail_get_prefix();
-        if (prefix) {
+	prefix = feh_thumbnail_get_prefix();
+	if (prefix) {
 		md5_name = feh_thumbnail_get_name_md5(uri);
 		thumb_file = estrjoin("/", prefix, md5_name, NULL);
 		free(md5_name);
-                free(prefix);
+		free(prefix);
 	}
 
 	return thumb_file;
@@ -705,7 +705,7 @@ int feh_thumbnail_generate(Imlib_Image * image, feh_file * file,
 			if (!feh_png_write_png_fd(*image, tmp_fd, "Thumb::URI", uri,
 					"Thumb::MTime", c_mtime,
 					"Thumb::Image::Width", c_width,
-					"Thumb::Image::Height", c_height)) { 
+					"Thumb::Image::Height", c_height)) {
 				rename(tmp_thumb_file, thumb_file);
 			} else {
 				unlink(tmp_thumb_file);
@@ -879,7 +879,7 @@ int feh_thumbnail_setup_thumbnail_dir(void)
 	struct stat sb;
 	char *dir, *p;
 
-        dir = feh_thumbnail_get_prefix();
+	dir = feh_thumbnail_get_prefix();
 
 	if (dir) {
 		if (!stat(dir, &sb)) {


### PR DESCRIPTION
This implements changes to the thumbnail generation to use `$XDG_CACHE_HOME`, respectively `$HOME/.cache/thumbnails`, c.f. #283. It's in "works for me" state, I was unsure about the different styles in the existing code and how much additional error checking should be done here.