### PR TITLE
Add actions to select the next/previous image when the scroll is done at the bottom/top edges

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -1402,21 +1402,37 @@ Scroll down.
 Note that the scroll keys work without anti-aliasing for performance reasons,
 hit the render key after scrolling to antialias the image.
 .
-.It Aq Alt+Left Bq scroll_left_page
+.It P Bq scroll_up_or_prev_img
+.
+Scroll up or show previous image. Selects the previous image in thumbnail mode.
+.
+.It N Bq scroll_down_or_next_img
+.
+Scroll down or show next image. Selects the next image in thumbnail mode.
+.
+.It Ao Alt+Left Ac Bq scroll_left_page
 .
 Scroll to the left by one page
 .
-.It Aq Alt+Right Bq scroll_right_page
+.It Ao Alt+Right Ac Bq scroll_right_page
 .
 Scroll to the right by one page
 .
-.It Aq Alt+Up Bq scroll_up_page
+.It Ao Alt+Up Ac Bq scroll_up_page
 .
 Scroll up by one page
 .
-.It Aq Alt+Down Bq scroll_down_page
+.It Ao Alt+Down Ac Bq scroll_down_page
 .
 Scroll down by one page
+.
+.It Ao Ctrl+P Ac Bq scroll_up_page_or_prev_img
+.
+Scroll up by one page or show previous image
+.
+.It Ao Ctrl+N Ac Bq scroll_down_page_or_next_img
+.
+Scroll down by one page or show next image
 .
 .It R, Ao keypad begin Ac Bq render
 .

--- a/src/help.raw
+++ b/src/help.raw
@@ -152,8 +152,10 @@ KEYS
  i                       Toggle --info display
  k                       Toggle zoom/viewport freeze when switching images
  m                       Show menu
+ N                       Move the image down or go to next image
  n, <SPACE>, <RIGHT>     Go to next image
  o                       Toggle pointer visibility
+ P                       Move the image up or go to previous image
  p, <BACKSPACE>, <LEFT>  Go to previous image
  q, <ESCAPE>             Quit
  r                       Reload image

--- a/src/options.h
+++ b/src/options.h
@@ -149,10 +149,14 @@ struct __fehkb {
 	struct __fehkey next_img;
 	struct __fehkey scroll_up;
 	struct __fehkey scroll_down;
+	struct __fehkey scroll_up_or_prev_img;
+	struct __fehkey scroll_down_or_next_img;
 	struct __fehkey scroll_right_page;
 	struct __fehkey scroll_left_page;
 	struct __fehkey scroll_up_page;
 	struct __fehkey scroll_down_page;
+	struct __fehkey scroll_up_page_or_prev_img;
+	struct __fehkey scroll_down_page_or_next_img;
 	struct __fehkey jump_back;
 	struct __fehkey quit;
 	struct __fehkey jump_fwd;


### PR DESCRIPTION
The new actions are:
- `scroll_down_or_next_img`, key P
- `scroll_up_or_prev_img`, key N
- `scroll_down_page_or_next_img`, key Ctrl+P
- `scroll_up_page_or_prev_img`, key Ctrl+N