### PR TITLE
Silence warnings

### DIFF
--- a/src/imlib.c
+++ b/src/imlib.c
@@ -1262,7 +1262,7 @@ void feh_draw_actions(winwidget w)
 	int i = 0;
 	int num_actions = 0;
 	int cur_action = 0;
-	char index[2];
+	char index[3];
 	char *line;
 
 	/* Count number of defined actions. This method sucks a bit since it needs

--- a/src/utils.c
+++ b/src/utils.c
@@ -157,7 +157,7 @@ char *feh_unique_filename(char *path, char *basename)
 {
 	char *tmpname;
 	char num[10];
-	char cppid[10];
+	char cppid[12];
 	static long int i = 1;
 	struct stat st;
 	pid_t ppid;


### PR DESCRIPTION
Silences the following two warnings with gcc-7.2.0. Please review to make sure this solution is correct.
```
imlib.c: In function ‘feh_draw_actions’:
imlib.c:1327:19: warning: ‘sprintf’ may write a terminating nul past the end of the destination [-Wformat-overflow=]
    sprintf(index, "%d", i);
                   ^~~~
imlib.c:1327:4: note: ‘sprintf’ output between 2 and 3 bytes into a destination of size 2
    sprintf(index, "%d", i);
    ^~~~~~~~~~~~~~~~~~~~~~~
utils.c:170:34: warning: ‘%06ld’ directive output may be truncated writing between 6 and 11 bytes into a region of size 10 [-Wformat-truncation=]
  snprintf(cppid, sizeof(cppid), "%06ld", (long) ppid);
                                  ^~~~~
utils.c:170:33: note: directive argument in the range [-2147483648, 2147483647]
  snprintf(cppid, sizeof(cppid), "%06ld", (long) ppid);
                                 ^~~~~~~
utils.c:170:2: note: ‘snprintf’ output between 7 and 12 bytes into a destination of size 10
  snprintf(cppid, sizeof(cppid), "%06ld", (long) ppid);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```