### PR TITLE
(src/Makefile) Manually set the target *.c files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,40 @@
 include ../config.mk
 
-TARGETS = ${shell echo *.c}
+TARGETS = \
+	collage.c \
+	events.c \
+	feh_png.c \
+	filelist.c \
+	getopt.c \
+	getopt1.c \
+	gib_hash.c \
+	gib_imlib.c \
+	gib_list.c \
+	gib_style.c \
+	imlib.c \
+	index.c \
+	keyevents.c \
+	list.c \
+	main.c \
+	md5.c \
+	menu.c \
+	multiwindow.c \
+	options.c \
+	signals.c \
+	slideshow.c \
+	thumbnail.c \
+	timers.c \
+	utils.c \
+	wallpaper.c \
+	winwidget.c
+
+ifeq (${exif},1)
+	TARGETS += \
+		exif.c \
+		exif_canon.c \
+		exif_nikon.c
+endif
+
 OBJECTS = ${TARGETS:.c=.o}
 
 I_SRCS = ${shell echo *.raw}


### PR DESCRIPTION
The current `src/Makefile` globs the all of the `*.c` files in `TARGETS` and will compile them even if their contents are hidden behind an `#ifdef` and essentially empty which will result in the following warnings.
```
cc -g -O2 -Wall -Wextra -pedantic -DHAVE_LIBCURL -DHAVE_LIBXINERAMA -DPREFIX=\"/usr/local\" -DPACKAGE=\"feh\" -DVERSION=\"2.19.3-4-g5cf2736\"   -c -o exif.o exif.c
exif.c:318:0: warning: ISO C forbids an empty translation unit [-Wpedantic]
 #endif
 
cc -g -O2 -Wall -Wextra -pedantic -DHAVE_LIBCURL -DHAVE_LIBXINERAMA -DPREFIX=\"/usr/local\" -DPACKAGE=\"feh\" -DVERSION=\"2.19.3-4-g5cf2736\"   -c -o exif_canon.o exif_canon.c
exif_canon.c:61:0: warning: ISO C forbids an empty translation unit [-Wpedantic]
 #endif
 
cc -g -O2 -Wall -Wextra -pedantic -DHAVE_LIBCURL -DHAVE_LIBXINERAMA -DPREFIX=\"/usr/local\" -DPACKAGE=\"feh\" -DVERSION=\"2.19.3-4-g5cf2736\"   -c -o exif_nikon.o exif_nikon.c
exif_nikon.c:510:0: warning: ISO C forbids an empty translation unit [-Wpedantic]
 #endif
 
```
By manually setting `TARGETS` only files that are needed will be compiled avoiding the warnings altogether as well as achieving greater control over the build process.