### PR TITLE
Silence -Wimplicit-fallthrough= warning

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -768,6 +768,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 			break;
 		case 240:
 			opt.insecure_ssl = 1;
+			break;
 		case 241:
 			opt.recursive = 0;
 		default:


### PR DESCRIPTION
Silences the following warning, my understanding is that `break;` was just accidentally left out here.
```
options.c: In function ‘feh_parse_option_array’:
options.c:770:21: warning: this statement may fall through [-Wimplicit-fallthrough=]
    opt.insecure_ssl = 1;
    ~~~~~~~~~~~~~~~~~^~~
options.c:771:3: note: here
   case 241:
   ^~~~
```