### PR TITLE
config.mk: Use prefix in ICON_PREFIX

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -14,7 +14,7 @@ PREFIX ?= /usr/local
 ICON_PREFIX ?= ${DESTDIR}${PREFIX}/share/icons
 
 ifeq (${app},1)
-	ICON_PREFIX = /usr/share/icons
+	ICON_PREFIX = ${PREFIX}/share/icons
 endif
 
 # Directories for manuals, executables, docs, data, etc.


### PR DESCRIPTION
The `PREFIX`, if specified, should also be used to determine the `ICON_PREFIX`

This was originally written by @mimi1vx who I've tagged here.