### PR TITLE
imlib: Look up CA certificates by $CURL_CA_BUNDLE.

### DIFF
--- a/src/imlib.c
+++ b/src/imlib.c
@@ -429,6 +429,10 @@ static char *feh_http_load_image(char *url)
 			if (opt.insecure_ssl) {
 				curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
 				curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
+			} else {
+				// Allow the user to specify custom CA certificates.
+				curl_easy_setopt(curl, CURLOPT_CAINFO,
+						getenv("CURL_CA_BUNDLE"));
 			}
 
 			res = curl_easy_perform(curl);


### PR DESCRIPTION
Hello!

This patch makes `feh` respect `$CURL_CA_BUNDLE`, just like `curl` does.  This makes it possible for users to specify a custom certificate directory instead of the `libcurl` builtin.