### PR TITLE
rand() should not be limited using modulo

### DIFF
--- a/src/keyevents.c
+++ b/src/keyevents.c
@@ -657,7 +657,7 @@ void feh_event_handle_generic(winwidget winwid, unsigned int state, KeySym keysy
 	}
 	else if (feh_is_kp(EVENT_jump_random, state, keysym, button)) {
 		if (winwid->type == WIN_TYPE_THUMBNAIL)
-			feh_thumbnail_select_next(winwid, rand() % (filelist_len - 1));
+			feh_thumbnail_select_next(winwid, ((double) rand() / RAND_MAX) * (filelist_len - 1));
 		else
 			slideshow_change_image(winwid, SLIDE_RAND, 1);
 	}

--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -290,7 +290,7 @@ void slideshow_change_image(winwidget winwid, int change, int render)
 		case SLIDE_RAND:
 			if (filelist_len > 1) {
 				current_file = feh_list_jump(filelist, current_file, FORWARD,
-					(rand() % (filelist_len - 1)) + 1);
+					( ((double) rand() / RAND_MAX) * (filelist_len - 1)) + 1);
 				change = SLIDE_NEXT;
 			}
 			break;


### PR DESCRIPTION
I noticed a interesting proclivity to choosing a certain group of images in a large folder when setting my backgrounds. No clue if this will change any of that but it is better to use random bits the right way.