### PR TITLE
Utilize the imlib cache properly

### DIFF
--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -1008,7 +1008,7 @@ void winwidget_rename(winwidget winwid, char *newname)
 void winwidget_free_image(winwidget w)
 {
 	if (w->im)
-		gib_imlib_free_image_and_decache(w->im);
+		gib_imlib_free_image(w->im);
 	w->im = NULL;
 	w->im_w = 0;
 	w->im_h = 0;


### PR DESCRIPTION
This prevents removing the image data from the cache, when moving back and forth between images. As suggested by the Imlib documentation: http://alien.cern.ch/cache/imlib2-1.0.6/doc/

This significantly reduces the delay in toggling between two images, when both images are in the imlib cache.