### PR TITLE
Add option to change the imlib cache size

### DIFF
--- a/src/help.raw
+++ b/src/help.raw
@@ -94,6 +94,7 @@ OPTIONS
      --min-dimension WxH   Only show images with width >= W and height >= H
      --max-dimension WxH   Only show images with width <= W and height <= H
      --scroll-step COUNT   scroll COUNT pixels when movement key is pressed
+     --cache-size NUM      imlib cache size in mebibytes (0 .. 2048)
 
 MONTAGE MODE OPTIONS
  -X, --ignore-aspect       Set thumbnail to specified width/height without

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -131,6 +131,8 @@ void init_x_and_imlib(void)
 	imlib_context_set_operation(IMLIB_OP_COPY);
 	wmDeleteWindow = XInternAtom(disp, "WM_DELETE_WINDOW", False);
 
+	imlib_set_cache_size(opt.cache_size * 1024 * 1024);
+
 	/* Initialise random numbers */
 	srand(getpid() * time(NULL) % ((unsigned int) -1));
 

--- a/src/options.c
+++ b/src/options.c
@@ -68,6 +68,7 @@ void init_parse_options(int argc, char **argv)
 	opt.jump_on_resort = 1;
 
 	opt.screen_clip = 1;
+	opt.cache_size = 4;
 #ifdef HAVE_LIBXINERAMA
 	/* if we're using xinerama, then enable it by default */
 	opt.xinerama = 1;
@@ -410,6 +411,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		{"xinerama-index", 1, 0, 239},
 		{"insecure"      , 0, 0, 240},
 		{"no-recursive"  , 0, 0, 241},
+		{"cache-size"    , 1, 0, 243},
 		{0, 0, 0, 0}
 	};
 	int optch = 0, cmdx = 0;
@@ -772,6 +774,14 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 			break;
 		case 241:
 			opt.recursive = 0;
+			break;
+		case 243:
+			opt.cache_size = atoi(optarg);
+			if (opt.cache_size < 0)
+				opt.cache_size = 0;
+			if (opt.cache_size > 2048)
+				opt.cache_size = 2048;
+			break;
 		default:
 			break;
 		}

--- a/src/options.h
+++ b/src/options.h
@@ -117,6 +117,9 @@ struct __fehoptions {
 	/* signed in case someone wants to invert scrolling real quick */
 	int scroll_step;
 
+	// imlib cache size in mebibytes
+	int cache_size;
+
 	unsigned int min_width, min_height, max_width, max_height;
 
 	unsigned char mode;


### PR DESCRIPTION
This option allows you to change the imlib2 image cache size.

Maybe we should also consider increasing the default cache size, which seems to be 4 MiB.