### PR TITLE
Preload the next image in the background

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -8,6 +8,7 @@ debug ?= 0
 help ?= 0
 xinerama ?= 1
 exif ?= 0
+pthread ?= 1
 
 # Prefix for all installed files
 PREFIX ?= /usr/local
@@ -35,7 +36,7 @@ scalable_icon_dir = ${icon_dir}/scalable/apps
 
 # default CFLAGS
 CFLAGS ?= -g -O2
-CFLAGS += -Wall -Wextra -pedantic -pthread
+CFLAGS += -Wall -Wextra -pedantic
 
 # Settings for glibc >= 2.19 - may need to be adjusted for other systems
 CFLAGS += -std=c11 -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=500
@@ -77,6 +78,14 @@ ifeq (${exif},1)
 	MAN_EXIF = enabled
 else
 	MAN_EXIF = disabled
+endif
+
+ifeq (${pthread},1)
+	CFLAGS += -DHAVE_LIBPTHREAD
+	LDLIBS += -lpthread
+	MAN_PTHREAD = enabled
+else
+	MAN_PTHREAD = disabled
 endif
 
 MAN_DATE ?= ${shell date '+%B %d, %Y'}

--- a/config.mk
+++ b/config.mk
@@ -8,7 +8,7 @@ debug ?= 0
 help ?= 0
 xinerama ?= 1
 exif ?= 0
-pthread ?= 1
+pthread ?= 0
 
 # Prefix for all installed files
 PREFIX ?= /usr/local

--- a/config.mk
+++ b/config.mk
@@ -35,7 +35,7 @@ scalable_icon_dir = ${icon_dir}/scalable/apps
 
 # default CFLAGS
 CFLAGS ?= -g -O2
-CFLAGS += -Wall -Wextra -pedantic
+CFLAGS += -Wall -Wextra -pedantic -pthread
 
 # Settings for glibc >= 2.19 - may need to be adjusted for other systems
 CFLAGS += -std=c11 -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=500

--- a/man/Makefile
+++ b/man/Makefile
@@ -13,6 +13,7 @@ all: ${TARGETS}
 	-e 's/\$$MAN_DEBUG\$$/${MAN_DEBUG}/' \
 	-e 's/\$$MAN_EXIF\$$/${MAN_EXIF}/' \
 	-e 's/\$$MAN_XINERAMA\$$/${MAN_XINERAMA}/' \
+	-e 's/\$$MAN_PTHREAD\$$/${MAN_PTHREAD}/' \
 	< ${@:.1=.pre} > $@
 
 clean:

--- a/src/filelist.c
+++ b/src/filelist.c
@@ -36,6 +36,7 @@ gib_list *filelist = NULL;
 gib_list *original_file_items = NULL; /* original file items from argv */
 int filelist_len = 0;
 gib_list *current_file = NULL;
+gib_list *next_file = NULL;
 extern int errno;
 
 static gib_list *rm_filelist = NULL;

--- a/src/filelist.c
+++ b/src/filelist.c
@@ -36,7 +36,9 @@ gib_list *filelist = NULL;
 gib_list *original_file_items = NULL; /* original file items from argv */
 int filelist_len = 0;
 gib_list *current_file = NULL;
+#ifdef HAVE_LIBPTHREAD
 gib_list *next_file = NULL;
+#endif
 extern int errno;
 
 static gib_list *rm_filelist = NULL;

--- a/src/filelist.h
+++ b/src/filelist.h
@@ -112,6 +112,8 @@ extern gib_list *filelist;
 extern gib_list *original_file_items;
 extern int filelist_len;
 extern gib_list *current_file;
+#ifdef HAVE_LIBPTHREAD
 extern gib_list *next_file;
+#endif
 
 #endif

--- a/src/filelist.h
+++ b/src/filelist.h
@@ -112,5 +112,6 @@ extern gib_list *filelist;
 extern gib_list *original_file_items;
 extern int filelist_len;
 extern gib_list *current_file;
+extern gib_list *next_file;
 
 #endif

--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -31,7 +31,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "options.h"
 #include "signals.h"
 
+#ifdef HAVE_LIBPTHREAD
 #include <pthread.h>
+#endif
 
 void init_slideshow_mode(void)
 {
@@ -246,6 +248,7 @@ void feh_reload_image(winwidget w, int resize, int force_new)
 	return;
 }
 
+#ifdef HAVE_LIBPTHREAD
 static void *thread_start(void *arg)
 {
 	feh_file *file = (feh_file*)arg;
@@ -261,11 +264,14 @@ static void *thread_start(void *arg)
 
 	return NULL;
 }
+#endif
 
 void slideshow_change_image(winwidget winwid, int change, int render)
 {
 	gib_list *last = NULL;
+#ifdef HAVE_LIBPTHREAD
 	gib_list *next_file = NULL;
+#endif
 	int i = 0;
 	int jmp = 1;
 	/* We can't use filelist_len in the for loop, since that changes when we
@@ -302,11 +308,15 @@ void slideshow_change_image(winwidget winwid, int change, int render)
 		switch (change) {
 		case SLIDE_NEXT:
 			current_file = feh_list_jump(filelist, current_file, FORWARD, 1);
+#ifdef HAVE_LIBPTHREAD
 			next_file = feh_list_jump(filelist, current_file, FORWARD, 1);
+#endif
 			break;
 		case SLIDE_PREV:
 			current_file = feh_list_jump(filelist, current_file, BACK, 1);
+#ifdef HAVE_LIBPTHREAD
 			next_file = feh_list_jump(filelist, current_file, BACK, 1);
+#endif
 			break;
 		case SLIDE_RAND:
 			if (filelist_len > 1) {
@@ -435,11 +445,13 @@ void slideshow_change_image(winwidget winwid, int change, int render)
 	if (last)
 		filelist = feh_file_remove_from_list(filelist, last);
 
+#ifdef HAVE_LIBPTHREAD
 	if (next_file) {
 		pthread_t thread_id;
 		feh_file *file = FEH_FILE(next_file->data);
 		pthread_create(&thread_id, NULL, &thread_start, file);
 	}
+#endif
 
 	if (filelist_len == 0)
 		eprintf("No more slides in show");

--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -31,6 +31,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "options.h"
 #include "signals.h"
 
+#include <pthread.h>
+
 void init_slideshow_mode(void)
 {
 	winwidget w = NULL;
@@ -244,9 +246,26 @@ void feh_reload_image(winwidget w, int resize, int force_new)
 	return;
 }
 
+static void *thread_start(void *arg)
+{
+	feh_file *file = (feh_file*)arg;
+
+	// Hack to prevent segfault when scrolling quickly through already cached images
+	nanosleep((const struct timespec[]){{0, 1000000L}}, NULL);
+
+	Imlib_Image im = imlib_load_image_immediately(file->filename);
+	if (im) {
+		imlib_context_set_image(im);
+		imlib_free_image();
+	}
+
+	return NULL;
+}
+
 void slideshow_change_image(winwidget winwid, int change, int render)
 {
 	gib_list *last = NULL;
+	gib_list *next_file = NULL;
 	int i = 0;
 	int jmp = 1;
 	/* We can't use filelist_len in the for loop, since that changes when we
@@ -283,9 +302,11 @@ void slideshow_change_image(winwidget winwid, int change, int render)
 		switch (change) {
 		case SLIDE_NEXT:
 			current_file = feh_list_jump(filelist, current_file, FORWARD, 1);
+			next_file = feh_list_jump(filelist, current_file, FORWARD, 1);
 			break;
 		case SLIDE_PREV:
 			current_file = feh_list_jump(filelist, current_file, BACK, 1);
+			next_file = feh_list_jump(filelist, current_file, BACK, 1);
 			break;
 		case SLIDE_RAND:
 			if (filelist_len > 1) {
@@ -413,6 +434,12 @@ void slideshow_change_image(winwidget winwid, int change, int render)
 	}
 	if (last)
 		filelist = feh_file_remove_from_list(filelist, last);
+
+	if (next_file) {
+		pthread_t thread_id;
+		feh_file *file = FEH_FILE(next_file->data);
+		pthread_create(&thread_id, NULL, &thread_start, file);
+	}
 
 	if (filelist_len == 0)
 		eprintf("No more slides in show");


### PR DESCRIPTION
This preloads the next image in the filelist into the imlib cache.

Closes: #103

- [x] Make it optional (compile flag or feh option)

This results in much faster toggling between images when combined with an increased `--cache-size`.