### PR TITLE
Apply the toggle_fixed_geometry event to current image

### DIFF
--- a/src/keyevents.c
+++ b/src/keyevents.c
@@ -769,6 +769,7 @@ void feh_event_handle_generic(winwidget winwid, unsigned int state, KeySym keysy
 			opt.geom_w = winwid->w;
 			opt.geom_h = winwid->h;
 		}
+		winwidget_render_image(winwid, 1, 0);
 	}
 	return;
 }


### PR DESCRIPTION
This will update the window dimensions and rerender the current image when the `toggle_fixed_geometry` event is raised.

Without this you have to jump back and forth between two images to get the desired effect.