### PR TITLE
Fix window auto-resize with --keep-zoom-vp enabled

### DIFF
--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -232,10 +232,8 @@ void feh_reload_image(winwidget w, int resize, int force_new)
 		w->im_x = tim_x;
 		w->im_y = tim_y;
 		w->zoom = tzoom;
-		winwidget_render_image(w, 0, 0);
-	} else {
-		winwidget_render_image(w, resize, 0);
 	}
+	winwidget_render_image(w, resize, 0);
 
 	winwidget_rename(w, title);
 	free(title);
@@ -396,11 +394,7 @@ void slideshow_change_image(winwidget winwid, int change, int render)
 				winwid->zoom = tzoom;
 			}
 			if (render) {
-				if (opt.keep_zoom_vp) {
-					winwidget_render_image(winwid, 0, 0);
-				} else {
-					winwidget_render_image(winwid, 1, 0);
-				}
+				winwidget_render_image(winwid, 1, 0);
 			}
 
 			s = slideshow_create_name(FEH_FILE(current_file->data), winwid);

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -434,7 +434,8 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 
 	if (!winwid->full_screen && resize) {
 		winwidget_resize(winwid, winwid->im_w, winwid->im_h, 0);
-		winwidget_reset_image(winwid);
+		if (!opt.keep_zoom_vp)
+			winwidget_reset_image(winwid);
 	}
 
 	/* bounds checks for panning */
@@ -470,7 +471,7 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 		feh_calc_needed_zoom(&(winwid->zoom), winwid->im_w, winwid->im_h, winwid->w, winwid->h);
 
 
-	if (resize && (winwid->type != WIN_TYPE_THUMBNAIL) &&
+	if (!opt.keep_zoom_vp && resize && (winwid->type != WIN_TYPE_THUMBNAIL) &&
 			(winwid->full_screen || (opt.geom_flags & (WidthValue | HeightValue)))) {
 		int smaller;	/* Is the image smaller than screen? */
 		int max_w = 0, max_h = 0;


### PR DESCRIPTION
`--keep-zoom-vp` will no longer block the dynamic window resizing mechanism.

This should make `--keep-zoom-vp` work as one would expect, when combined with #358.