### PR TITLE
Fix zoom ratio calculation

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -592,6 +592,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 				opt.filelistfile = estrdup(optarg);
 			break;
 		case 'g':
+			opt.geom_enabled = 1;
 			opt.geom_flags = XParseGeometry(optarg, &opt.geom_x,
 					&opt.geom_y, &opt.geom_w, &opt.geom_h);
 			break;

--- a/src/options.h
+++ b/src/options.h
@@ -106,6 +106,7 @@ struct __fehoptions {
 	int sort;
 	int version_sort;
 	int debug;
+	int geom_enabled;
 	int geom_flags;
 	int geom_x;
 	int geom_y;

--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -143,16 +143,6 @@ void feh_reload_image(winwidget w, int resize, int force_new)
 	Imlib_Image tmp;
 	int old_w, old_h;
 
-	unsigned char tmode =0;
-	int tim_x =0;
-	int tim_y =0;
-	double tzoom =0;
-
-	tmode = w->mode;
-	tim_x = w->im_x;
-	tim_y = w->im_y;
-	tzoom = w->zoom;
-
 	if (!w->file) {
 		im_weprintf(w, "couldn't reload, this image has no file associated with it.");
 		winwidget_render_image(w, 0, 0);
@@ -217,13 +207,6 @@ void feh_reload_image(winwidget w, int resize, int force_new)
 		w->im_w = gib_imlib_image_get_width(w->im);
 		w->im_h = gib_imlib_image_get_height(w->im);
 	}
-	if (opt.keep_zoom_vp) {
-		/* put back in: */
-		w->mode = tmode;
-		w->im_x = tim_x;
-		w->im_y = tim_y;
-		w->zoom = tzoom;
-	}
 	winwidget_render_image(w, resize, 0);
 
 	return;
@@ -238,11 +221,6 @@ void slideshow_change_image(winwidget winwid, int change, int render)
 	 * encounter invalid images.
 	 */
 	int our_filelist_len = filelist_len;
-
-	unsigned char tmode =0;
-	int tim_x =0;
-	int tim_y =0;
-	double tzoom =0;
 
 	/* Without this, clicking a one-image slideshow reloads it. Not very *
 	   intelligent behaviour :-) */
@@ -354,14 +332,6 @@ void slideshow_change_image(winwidget winwid, int change, int render)
 			last = NULL;
 		}
 
-		if (opt.keep_zoom_vp) {
-		/* pre loadimage - record settings */
-			tmode = winwid->mode;
-			tim_x = winwid->im_x;
-			tim_y = winwid->im_y;
-			tzoom = winwid->zoom;
-		}
-
 		if (winwidget_loadimage(winwid, FEH_FILE(current_file->data))) {
 			int w = gib_imlib_image_get_width(winwid->im);
 			int h = gib_imlib_image_get_height(winwid->im);
@@ -376,13 +346,6 @@ void slideshow_change_image(winwidget winwid, int change, int render)
 			winwidget_reset_image(winwid);
 			winwid->im_w = w;
 			winwid->im_h = h;
-			if (opt.keep_zoom_vp) {
-				/* put back in: */
-				winwid->mode = tmode;
-				winwid->im_x = tim_x;
-				winwid->im_y = tim_y;
-				winwid->zoom = tzoom;
-			}
 			if (render) {
 				winwidget_render_image(winwid, 1, 0);
 			}

--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -223,10 +223,8 @@ void feh_reload_image(winwidget w, int resize, int force_new)
 		w->im_x = tim_x;
 		w->im_y = tim_y;
 		w->zoom = tzoom;
-		winwidget_render_image(w, 0, 0);
-	} else {
-		winwidget_render_image(w, resize, 0);
 	}
+	winwidget_render_image(w, resize, 0);
 
 	return;
 }
@@ -386,11 +384,7 @@ void slideshow_change_image(winwidget winwid, int change, int render)
 				winwid->zoom = tzoom;
 			}
 			if (render) {
-				if (opt.keep_zoom_vp) {
-					winwidget_render_image(winwid, 0, 0);
-				} else {
-					winwidget_render_image(winwid, 1, 0);
-				}
+				winwidget_render_image(winwid, 1, 0);
 			}
 			break;
 		} else

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -426,8 +426,7 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 
 	if (!winwid->full_screen && resize) {
 		winwidget_resize(winwid, winwid->im_w, winwid->im_h, 0);
-		if (!opt.keep_zoom_vp)
-			winwidget_reset_image(winwid);
+		winwidget_reset_image(winwid);
 	}
 
 	D(("winwidget_render_image resize %d force_alias %d im %dx%d\n",
@@ -953,10 +952,12 @@ void feh_debug_print_winwid(winwidget w)
 
 void winwidget_reset_image(winwidget winwid)
 {
-	winwid->zoom = 1.0;
-	winwid->old_zoom = 1.0;
-	winwid->im_x = 0;
-	winwid->im_y = 0;
+	if (!opt.keep_zoom_vp) {
+		winwid->zoom = 1.0;
+		winwid->old_zoom = 1.0;
+		winwid->im_x = 0;
+		winwid->im_y = 0;
+	}
 	winwid->im_angle = 0.0;
 	winwid->has_rotated = 0;
 	return;

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -429,12 +429,6 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 		winwidget_reset_image(winwid);
 	}
 
-	/* bounds checks for panning */
-	if (winwid->im_x > winwid->w)
-		winwid->im_x = winwid->w;
-	if (winwid->im_y > winwid->h)
-		winwid->im_y = winwid->h;
-
 	D(("winwidget_render_image resize %d force_alias %d im %dx%d\n",
 	      resize, force_alias, winwid->im_w, winwid->im_h));
 

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -445,8 +445,9 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 
 	if (!winwid->full_screen && ((gib_imlib_image_has_alpha(winwid->im))
 				     || (opt.geom_flags & (WidthValue | HeightValue))
-				     || (winwid->im_x || winwid->im_y) || (winwid->zoom != 1.0)
-				     || (winwid->w > winwid->im_w || winwid->h > winwid->im_h)
+				     || (winwid->im_x || winwid->im_y)
+				     || (winwid->w > winwid->im_w * winwid->zoom)
+				     || (winwid->h > winwid->im_h * winwid->zoom)
 				     || (winwid->has_rotated)))
 		feh_draw_checks(winwid);
 

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -443,14 +443,6 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 
 	winwidget_setup_pixmaps(winwid);
 
-	if (!winwid->full_screen && ((gib_imlib_image_has_alpha(winwid->im))
-				     || (opt.geom_flags & (WidthValue | HeightValue))
-				     || (winwid->im_x || winwid->im_y)
-				     || (winwid->w > winwid->im_w * winwid->zoom)
-				     || (winwid->h > winwid->im_h * winwid->zoom)
-				     || (winwid->has_rotated)))
-		feh_draw_checks(winwid);
-
 	if (had_resize && !opt.keep_zoom_vp && (winwid->type != WIN_TYPE_THUMBNAIL)) {
 		double required_zoom = 1.0;
 		feh_calc_needed_zoom(&required_zoom, winwid->im_w, winwid->im_h, winwid->w, winwid->h);
@@ -498,6 +490,14 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 
 	if (opt.keep_zoom_vp)
 		winwidget_sanitise_offsets(winwid);
+
+	if (!winwid->full_screen && ((gib_imlib_image_has_alpha(winwid->im))
+				     || (opt.geom_flags & (WidthValue | HeightValue))
+				     || (winwid->im_x || winwid->im_y)
+				     || (winwid->w > winwid->im_w * winwid->zoom)
+				     || (winwid->h > winwid->im_h * winwid->zoom)
+				     || (winwid->has_rotated)))
+		feh_draw_checks(winwid);
 
 	/* Now we ensure only to render the area we're looking at */
 	dx = winwid->im_x;

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -426,7 +426,8 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 
 	if (!winwid->full_screen && resize) {
 		winwidget_resize(winwid, winwid->im_w, winwid->im_h, 0);
-		winwidget_reset_image(winwid);
+		if (!opt.keep_zoom_vp)
+			winwidget_reset_image(winwid);
 	}
 
 	D(("winwidget_render_image resize %d force_alias %d im %dx%d\n",

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -323,7 +323,7 @@ void winwidget_create_window(winwidget ret, int w, int h)
 	winwidget_register(ret);
 
 	/* do not scale down a thumbnail list window, only those created from it */
-	if (opt.scale_down && (ret->type != WIN_TYPE_THUMBNAIL)) {
+	if (opt.geom_enabled && (ret->type != WIN_TYPE_THUMBNAIL)) {
 		opt.geom_w = w;
 		opt.geom_h = h;
 		opt.geom_flags |= WidthValue | HeightValue;

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -450,33 +450,23 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 				&& (!opt.default_zoom || required_zoom < winwid->zoom))
 			winwid->zoom = required_zoom;
 
-		winwid->im_x = (int) (winwid->w - (winwid->im_w * winwid->zoom)) >> 1;
-		winwid->im_y = (int) (winwid->h - (winwid->im_h * winwid->zoom)) >> 1;
-	}
-
-	/*
-	 * Adjust X/Y offset if the image is larger than the window and
-	 * --inner-geometry is set. This will cause odd behaviour when
-	 * zooming an already large image in --inner-geometry mode, but in most
-	 * cases this should be what the user wants. Plus, it doesn't require
-	 * fiddling around in two or three places above, so it's the best
-	 * solution considering a future refactoring of this function.
-	 */
-
-	if (had_resize) {
-		if ((opt.offset_flags & XValue) && (winwid->im_w * winwid->zoom) > winwid->w) {
+		if (opt.offset_flags & XValue) {
 			if (opt.offset_flags & XNegative) {
 				winwid->im_x = winwid->w - (winwid->im_w * winwid->zoom) - opt.offset_x;
 			} else {
 				winwid->im_x = - opt.offset_x * winwid->zoom;
 			}
+		} else {
+			winwid->im_x = (int) (winwid->w - (winwid->im_w * winwid->zoom)) >> 1;
 		}
-		if ((opt.offset_flags & YValue) && (winwid->im_h * winwid->zoom) > winwid->h) {
+		if (opt.offset_flags & YValue) {
 			if (opt.offset_flags & YNegative) {
 				winwid->im_y = winwid->h - (winwid->im_h * winwid->zoom) - opt.offset_y;
 			} else {
 				winwid->im_y = - opt.offset_y * winwid->zoom;
 			}
+		} else {
+			winwid->im_y = (int) (winwid->h - (winwid->im_h * winwid->zoom)) >> 1;
 		}
 	}
 

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -806,10 +806,10 @@ void winwidget_resize(winwidget winwid, int w, int h, int force_resize)
 	D(("   x %d y %d w %d h %d\n", attributes.x, attributes.y, winwid->w,
 		winwid->h));
 
-    if ((opt.geom_flags & (WidthValue | HeightValue)) && !force_resize) {
-        winwid->had_resize = 1;
-        return;
-    }
+	if ((opt.geom_flags & (WidthValue | HeightValue)) && !force_resize) {
+		winwid->had_resize = 1;
+		return;
+	}
 	if (winwid && ((winwid->w != w) || (winwid->h != h))) {
 		if (opt.screen_clip) {
 			double required_zoom = 1.0;
@@ -820,13 +820,12 @@ void winwidget_resize(winwidget winwid, int w, int h, int force_resize)
 			winwid->h = winwid->im_h * required_zoom;
 		}
 		if (winwid->full_screen) {
-            XTranslateCoordinates(disp, winwid->win, attributes.root,
-                        -attributes.border_width -
-                        attributes.x,
-                        -attributes.border_width - attributes.y, &tc_x, &tc_y, &dw);
-            winwid->x = tc_x;
-            winwid->y = tc_y;
-            XMoveResizeWindow(disp, winwid->win, tc_x, tc_y, winwid->w, winwid->h);
+			XTranslateCoordinates(disp, winwid->win, attributes.root,
+						-attributes.border_width - attributes.x,
+						-attributes.border_width - attributes.y, &tc_x, &tc_y, &dw);
+			winwid->x = tc_x;
+			winwid->y = tc_y;
+			XMoveResizeWindow(disp, winwid->win, tc_x, tc_y, winwid->w, winwid->h);
 		} else
 			XResizeWindow(disp, winwid->win, winwid->w, winwid->h);
 

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -820,8 +820,12 @@ void winwidget_resize(winwidget winwid, int w, int h, int force_resize)
 	if (winwid && ((winwid->w != w) || (winwid->h != h))) {
 		/* winwidget_clear_background(winwid); */
 		if (opt.screen_clip) {
-            winwid->w = (w > scr_width) ? scr_width : w;
-            winwid->h = (h > scr_height) ? scr_height : h;
+			double required_zoom = 1.0;
+			int max_w = (w > scr_width) ? scr_width : w;
+			int max_h = (h > scr_height) ? scr_height : h;
+			feh_calc_needed_zoom(&required_zoom, winwid->im_w, winwid->im_h, max_w, max_h);
+			winwid->w = winwid->im_w * required_zoom;
+			winwid->h = winwid->im_h * required_zoom;
 		}
 		if (winwid->full_screen) {
             XTranslateCoordinates(disp, winwid->win, attributes.root,

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -645,13 +645,6 @@ Pixmap feh_create_checks(void)
 	return(checks_pmap);
 }
 
-void winwidget_clear_background(winwidget w)
-{
-	XSetWindowBackgroundPixmap(disp, w->win, feh_create_checks());
-	/* XClearWindow(disp, w->win); */
-	return;
-}
-
 void feh_draw_checks(winwidget win)
 {
 	static GC gc = None;
@@ -818,7 +811,6 @@ void winwidget_resize(winwidget winwid, int w, int h, int force_resize)
         return;
     }
 	if (winwid && ((winwid->w != w) || (winwid->h != h))) {
-		/* winwidget_clear_background(winwid); */
 		if (opt.screen_clip) {
 			double required_zoom = 1.0;
 			int max_w = (w > scr_width) ? scr_width : w;

--- a/src/winwidget.h
+++ b/src/winwidget.h
@@ -146,7 +146,6 @@ winwidget winwidget_create_from_image(Imlib_Image im, char type);
 void winwidget_rename(winwidget winwid, char *newname);
 void winwidget_destroy(winwidget winwid);
 void winwidget_create_window(winwidget ret, int w, int h);
-void winwidget_clear_background(winwidget w);
 Pixmap feh_create_checks(void);
 double feh_calc_needed_zoom(double *zoom, int orig_w, int orig_h, int dest_w, int dest_h);
 void feh_debug_print_winwid(winwidget winwid);


### PR DESCRIPTION
This simplifies the logic behind the automatic zoom ratio calculation, which is used by both `--auto-zoom` and `--scale-down`.

When merged this will:
* Improve the performance (especially in fullscreen mode)
* Fix the `w` command when both `--scale-down` and `--keep-zoom-vp` are enabled
* Fix `--auto-zoom` not being triggered on window resize events when `--scale-down` is enabled
* Fix `--auto-zoom` not being applied to the first image
* Fix `--auto-zoom` conflicting with manual zoom
* Fix `--zoom <percent> --auto-zoom` logic according to the `man feh` description
* Fix `feh_draw_checks` not taking the zoom level into account properly
* Fix `feh_draw_checks` being called before the zoom level is adjusted
* Prevent `--zoom <percent>` from blocking `--scale-down` in fullscreen / fixed geometry mode
* Prevent `--keep-zoom-vp` from blocking the dynamic window resizing mechanism
* Prevent automatic recalculation of the zoom ratio when `--keep_zoom_vp` is enabled
* Prevent `winwid-> im_x` and `winwid-> im_y` from being set to invalid values
(when switching between images of different sizes)
* Simplify the way `--keep-zoom-vp` is handled internally

Fixes: #229
Fixes: #244
Fixes: #307 

Closes: https://github.com/derf/feh/pull/358
Closes: https://github.com/derf/feh/pull/361
Closes: https://github.com/derf/feh/pull/362