### PR TITLE
 Fix screen-clip feature

### DIFF
--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -232,10 +232,8 @@ void feh_reload_image(winwidget w, int resize, int force_new)
 		w->im_x = tim_x;
 		w->im_y = tim_y;
 		w->zoom = tzoom;
-		winwidget_render_image(w, 0, 0);
-	} else {
-		winwidget_render_image(w, resize, 0);
 	}
+	winwidget_render_image(w, resize, 0);
 
 	winwidget_rename(w, title);
 	free(title);
@@ -396,11 +394,7 @@ void slideshow_change_image(winwidget winwid, int change, int render)
 				winwid->zoom = tzoom;
 			}
 			if (render) {
-				if (opt.keep_zoom_vp) {
-					winwidget_render_image(winwid, 0, 0);
-				} else {
-					winwidget_render_image(winwid, 1, 0);
-				}
+				winwidget_render_image(winwid, 1, 0);
 			}
 
 			s = slideshow_create_name(FEH_FILE(current_file->data), winwid);

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -431,7 +431,8 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 
 	if (!winwid->full_screen && resize) {
 		winwidget_resize(winwid, winwid->im_w, winwid->im_h, 0);
-		winwidget_reset_image(winwid);
+		if (!opt.keep_zoom_vp)
+			winwidget_reset_image(winwid);
 	}
 
 	D(("winwidget_render_image resize %d force_alias %d im %dx%d\n",

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -331,12 +331,10 @@ void winwidget_create_window(winwidget ret, int w, int h)
 
 	winwidget_register(ret);
 
-	/* do not scale down a thumbnail list window, only those created from it */
-	if (opt.scale_down && (ret->type != WIN_TYPE_THUMBNAIL)) {
-		opt.geom_w = w;
-		opt.geom_h = h;
-		opt.geom_flags |= WidthValue | HeightValue;
-	}
+	opt.geom_w = w;
+	opt.geom_h = h;
+	opt.geom_flags |= WidthValue | HeightValue;
+
 	return;
 }
 
@@ -430,7 +428,6 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 	int sx, sy, sw, sh, dx, dy, dw, dh;
 	int calc_w, calc_h;
 	int antialias = 0;
-	int need_center = winwid->had_resize;
 
 	if (!winwid->full_screen && resize) {
 		winwidget_resize(winwid, winwid->im_w, winwid->im_h, 0);
@@ -446,6 +443,9 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 	D(("winwidget_render_image resize %d force_alias %d im %dx%d\n",
 	      resize, force_alias, winwid->im_w, winwid->im_h));
 
+	// winwidget_setup_pixmaps(winwid) resets the winwid->had_resize flag
+	int had_resize = winwid->had_resize || resize;
+
 	winwidget_setup_pixmaps(winwid);
 
 	if (!winwid->full_screen && ((gib_imlib_image_has_alpha(winwid->im))
@@ -455,113 +455,29 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 				     || (winwid->has_rotated)))
 		feh_draw_checks(winwid);
 
-	if (!winwid->full_screen && opt.zoom_mode && (winwid->type != WIN_TYPE_THUMBNAIL)
-				&& (winwid->zoom == 1.0) && ! (opt.geom_flags & (WidthValue | HeightValue))
-				&& (winwid->w > winwid->im_w) && (winwid->h > winwid->im_h))
-		feh_calc_needed_zoom(&(winwid->zoom), winwid->im_w, winwid->im_h, winwid->w, winwid->h);
+	if (had_resize && !opt.keep_zoom_vp && (winwid->type != WIN_TYPE_THUMBNAIL)) {
+		if (opt.default_zoom)
+			winwid->zoom = 0.01 * opt.default_zoom;
+		else
+			winwid->zoom = 1.0;
 
-	/*
-	 * In case of a resize, the geomflags (and im_w, im_h) get updated by
-	 * the ConfigureNotify handler.
-	 */
-	if (need_center && !winwid->full_screen && (winwid->type != WIN_TYPE_THUMBNAIL)
-				&& (opt.geom_flags & (WidthValue | HeightValue))
-				&& ((winwid->w < winwid->im_w) || (winwid->h < winwid->im_h)))
-		feh_calc_needed_zoom(&(winwid->zoom), winwid->im_w, winwid->im_h, winwid->w, winwid->h);
+		double required_zoom = 1.0;
+		feh_calc_needed_zoom(&required_zoom, winwid->im_w, winwid->im_h, winwid->w, winwid->h);
 
+		if (opt.scale_down && winwid->zoom > required_zoom)
+			winwid->zoom = required_zoom;
+		else if ((opt.zoom_mode && required_zoom > 1)
+				&& (!opt.default_zoom || required_zoom < winwid->zoom))
+			winwid->zoom = required_zoom;
 
-	if (resize && (winwid->type != WIN_TYPE_THUMBNAIL) &&
-			(winwid->full_screen || (opt.geom_flags & (WidthValue | HeightValue)))) {
-		int smaller;	/* Is the image smaller than screen? */
-		int max_w = 0, max_h = 0;
-
-		if (winwid->full_screen) {
-			max_w = scr->width;
-			max_h = scr->height;
-#ifdef HAVE_LIBXINERAMA
-			if (opt.xinerama && xinerama_screens) {
-				max_w = xinerama_screens[xinerama_screen].width;
-				max_h = xinerama_screens[xinerama_screen].height;
-			}
-#endif				/* HAVE_LIBXINERAMA */
-		} else {
-			if (opt.geom_flags & WidthValue) {
-				max_w = opt.geom_w;
-			}
-			if (opt.geom_flags & HeightValue) {
-				max_h = opt.geom_h;
-			}
-		}
-
-		D(("Calculating for fullscreen/fixed geom render\n"));
-		smaller = ((winwid->im_w < max_w)
-			   && (winwid->im_h < max_h));
-
-		if (!smaller || opt.zoom_mode) {
-			/* contributed by Jens Laas <jens.laas@data.slu.se>
-			 * What it does:
-			 * zooms images by a fixed amount but never larger than the screen.
-			 *
-			 * Why:
-			 * This is nice if you got a collection of images where some
-			 * are small and can stand a small zoom. Large images are unaffected.
-			 *
-			 * When does it work, and how?
-			 * You have to be in fullscreen mode _and_ have auto-zoom turned on.
-			 *   "feh -FZ --zoom 130 imagefile" will do the trick.
-			 *        -zoom percent - the new switch.
-			 *                        100 = orignal size,
-			 *                        130 is 30% larger.
-			 */
-			if (opt.default_zoom) {
-				double old_zoom = winwid->zoom;
-
-				winwid->zoom = 0.01 * opt.default_zoom;
-				if (opt.default_zoom != 100) {
-					if ((winwid->im_h * winwid->zoom) > max_h)
-						winwid->zoom = old_zoom;
-					else if ((winwid->im_w * winwid->zoom) > max_w)
-						winwid->zoom = old_zoom;
-				}
-
-				winwid->im_x = ((int)
-						(max_w - (winwid->im_w * winwid->zoom))) >> 1;
-				winwid->im_y = ((int)
-						(max_h - (winwid->im_h * winwid->zoom))) >> 1;
-			} else {
-				/* Image is larger than the screen (so wants shrinking), or it's
-				   smaller but wants expanding to fill it */
-				double ratio = feh_calc_needed_zoom(&(winwid->zoom), winwid->im_w, winwid->im_h, max_w, max_h);
-
-				if (ratio > 1.0) {
-					/* height is the factor */
-					winwid->im_x = 0;
-					winwid->im_y = ((int)
-							(max_h - (winwid->im_h * winwid->zoom))) >> 1;
-				} else {
-					/* width is the factor */
-					winwid->im_x = ((int)
-							(max_w - (winwid->im_w * winwid->zoom))) >> 1;
-					winwid->im_y = 0;
-				}
-			}
-		} else {
-			/* my modification to jens hack, allow --zoom without auto-zoom mode */
-			if (opt.default_zoom) {
-				winwid->zoom = 0.01 * opt.default_zoom;
-			} else {
-				winwid->zoom = 1.0;
-			}
-			/* Just center the image in the window */
-			winwid->im_x = (int) (max_w - (winwid->im_w * winwid->zoom)) >> 1;
-			winwid->im_y = (int) (max_h - (winwid->im_h * winwid->zoom)) >> 1;
-		}
-	}
-	else if (need_center && !winwid->full_screen
-			&& (winwid->type != WIN_TYPE_THUMBNAIL) && !opt.keep_zoom_vp) {
 		winwid->im_x = (int) (winwid->w - (winwid->im_w * winwid->zoom)) >> 1;
 		winwid->im_y = (int) (winwid->h - (winwid->im_h * winwid->zoom)) >> 1;
 	}
+
+	winwid->had_resize = 0;
+
+	if (opt.keep_zoom_vp)
+		winwidget_sanitise_offsets(winwid);
 
 	/* Now we ensure only to render the area we're looking at */
 	dx = winwid->im_x;

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -434,12 +434,6 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 		winwidget_reset_image(winwid);
 	}
 
-	/* bounds checks for panning */
-	if (winwid->im_x > winwid->w)
-		winwid->im_x = winwid->w;
-	if (winwid->im_y > winwid->h)
-		winwid->im_y = winwid->h;
-
 	D(("winwidget_render_image resize %d force_alias %d im %dx%d\n",
 	      resize, force_alias, winwid->im_w, winwid->im_h));
 

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -450,8 +450,9 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 
 	if (!winwid->full_screen && ((gib_imlib_image_has_alpha(winwid->im))
 				     || (opt.geom_flags & (WidthValue | HeightValue))
-				     || (winwid->im_x || winwid->im_y) || (winwid->zoom != 1.0)
-				     || (winwid->w > winwid->im_w || winwid->h > winwid->im_h)
+				     || (winwid->im_x || winwid->im_y)
+				     || (winwid->w > winwid->im_w * winwid->zoom)
+				     || (winwid->h > winwid->im_h * winwid->zoom)
 				     || (winwid->has_rotated)))
 		feh_draw_checks(winwid);
 

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -448,14 +448,6 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 
 	winwidget_setup_pixmaps(winwid);
 
-	if (!winwid->full_screen && ((gib_imlib_image_has_alpha(winwid->im))
-				     || (opt.geom_flags & (WidthValue | HeightValue))
-				     || (winwid->im_x || winwid->im_y)
-				     || (winwid->w > winwid->im_w * winwid->zoom)
-				     || (winwid->h > winwid->im_h * winwid->zoom)
-				     || (winwid->has_rotated)))
-		feh_draw_checks(winwid);
-
 	if (had_resize && !opt.keep_zoom_vp && (winwid->type != WIN_TYPE_THUMBNAIL)) {
 		if (opt.default_zoom)
 			winwid->zoom = 0.01 * opt.default_zoom;
@@ -479,6 +471,14 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 
 	if (opt.keep_zoom_vp)
 		winwidget_sanitise_offsets(winwid);
+
+	if (!winwid->full_screen && ((gib_imlib_image_has_alpha(winwid->im))
+				     || (opt.geom_flags & (WidthValue | HeightValue))
+				     || (winwid->im_x || winwid->im_y)
+				     || (winwid->w > winwid->im_w * winwid->zoom)
+				     || (winwid->h > winwid->im_h * winwid->zoom)
+				     || (winwid->has_rotated)))
+		feh_draw_checks(winwid);
 
 	/* Now we ensure only to render the area we're looking at */
 	dx = winwid->im_x;

--- a/src/winwidget.h
+++ b/src/winwidget.h
@@ -84,7 +84,7 @@ struct __winwidget {
 	int force_aliasing;
 	double im_angle;
 	enum win_type type;
-	unsigned char had_resize, full_screen;
+	unsigned char had_force_resize, had_resize, full_screen;
 	Imlib_Image im;
 	GC gc;
 	Pixmap bg_pmap;


### PR DESCRIPTION
By default, window sizes are now limited to screen size. Unless --no-screen-clip is activated. As described on the man page.

Depends on: https://github.com/derf/feh/pull/364