### PR TITLE
fflush in src/list.c to make tested behavior consistent across glibc and musl

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -92,6 +92,7 @@ void real_loadables_mode(int loadable)
 				if (opt.verbose)
 					feh_display_status('.');
 				puts(file->filename);
+				fflush(stdout);
 				feh_action_run(file, opt.actions[0], NULL);
 			}
 			else {
@@ -106,6 +107,7 @@ void real_loadables_mode(int loadable)
 				if (opt.verbose)
 					feh_display_status('.');
 				puts(file->filename);
+				fflush(stdout);
 				feh_action_run(file, opt.actions[0], NULL);
 			}
 			else {

--- a/test/nx_action/loadable_action
+++ b/test/nx_action/loadable_action
@@ -1,8 +1,8 @@
-touch test/ok/gif
-touch test/ok/jpg
-touch test/ok/png
-touch test/ok/pnm
 test/ok/gif
+touch test/ok/gif
 test/ok/jpg
+touch test/ok/jpg
 test/ok/png
+touch test/ok/png
 test/ok/pnm
+touch test/ok/pnm

--- a/test/nx_action/loadable_naction
+++ b/test/nx_action/loadable_naction
@@ -1,8 +1,8 @@
-touch test/ok/gif
-touch test/ok/jpg
-touch test/ok/png
-touch test/ok/pnm
 test/ok/gif
+touch test/ok/gif
 test/ok/jpg
+touch test/ok/jpg
 test/ok/png
+touch test/ok/png
 test/ok/pnm
+touch test/ok/pnm

--- a/test/nx_action/unloadable_action
+++ b/test/nx_action/unloadable_action
@@ -1,8 +1,8 @@
-rm test/fail/gif
-rm test/fail/jpg
-rm test/fail/png
-rm test/fail/pnm
 test/fail/gif
+rm test/fail/gif
 test/fail/jpg
+rm test/fail/jpg
 test/fail/png
+rm test/fail/png
 test/fail/pnm
+rm test/fail/pnm

--- a/test/nx_action/unloadable_naction
+++ b/test/nx_action/unloadable_naction
@@ -1,8 +1,8 @@
-rm test/fail/gif
-rm test/fail/jpg
-rm test/fail/png
-rm test/fail/pnm
 test/fail/gif
+rm test/fail/gif
 test/fail/jpg
+rm test/fail/jpg
 test/fail/png
+rm test/fail/png
 test/fail/pnm
+rm test/fail/pnm


### PR DESCRIPTION
On glibc, if output is redirected to a file, output will look like this:

touch test/ok/gif
touch test/ok/jpg
touch test/ok/png
touch test/ok/pnm
test/ok/gif
test/ok/jpg
test/ok/png
test/ok/pnm

On musl, if stdout is redirected to a file, output looks like this:

test/ok/gif
touch test/ok/gif
touch test/ok/jpg
touch test/ok/png
touch test/ok/pnm
test/ok/jpg
test/ok/png
test/ok/pnm

On glibc and musl, if stdout is interactive, it looks like this:

test/ok/gif
touch test/ok/gif
test/ok/jpg
touch test/ok/jpg
test/ok/png
touch test/ok/png
test/ok/pnm
touch test/ok/pnm

Adding two fflush calls makes all behavior look like the last example.
Test cases have been updated accordingly.