### PR TITLE
Adjust CFLAGS to fix compilation on musl

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -38,7 +38,7 @@ CFLAGS ?= -g -O2
 CFLAGS += -Wall -Wextra -pedantic
 
 # Settings for glibc >= 2.19 - may need to be adjusted for other systems
-CFLAGS += -std=c11 -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=500
+CFLAGS += -std=c11 -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700
 
 ifeq (${curl},1)
 	CFLAGS += -DHAVE_LIBCURL


### PR DESCRIPTION
With `-D_XOPEN_SOURCE=500`, there appears to be some sort of namespace conflict between strings.h and feh's source, specifically with regards to `index` or `rindex`. This prevents compilation on musl:

```
cc -g -O2 -Wall -Wextra -pedantic -std=c11 -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=500 -DHAVE_LIBCURL -DHAVE_LIBXINERAMA -DPREFIX=\"/usr/local\" -DPACKAGE=\"feh\" -DVERSION=\"2.23\"   -c -o options.o options.c
In file included from feh.h:33:0,
                 from options.c:27:
/usr/include/strings.h:19:7: error: expected declaration specifiers or '...' before '(' token
 char *index (const char *, int);
       ^
/usr/include/strings.h:19:7: error: expected declaration specifiers or '...' before '(' token
 char *index (const char *, int);
       ^
/usr/include/strings.h:20:7: error: expected declaration specifiers or '...' before '(' token
 char *rindex (const char *, int);
       ^
/usr/include/strings.h:20:7: error: expected declaration specifiers or '...' before '(' token
 char *rindex (const char *, int);
       ^
make[1]: *** [<builtin>: options.o] Error 1
```

Changing to `-D_XOPEN_SOURCE=700` fixes the issue.