### PR TITLE
Handle --min-dimension and --max-dimension without preload

### DIFF
--- a/src/filelist.c
+++ b/src/filelist.c
@@ -464,9 +464,7 @@ int feh_cmp_format(void *file1, void *file2)
 
 void feh_prepare_filelist(void)
 {
-	if (opt.list || opt.customlist || (opt.sort > SORT_MTIME)
-			|| opt.preload || opt.min_width || opt.min_height
-			|| (opt.max_width != UINT_MAX) || (opt.max_height != UINT_MAX)) {
+	if (opt.list || opt.preload || opt.customlist || (opt.sort > SORT_MTIME)) {
 		/* For these sort options, we have to preload images */
 		filelist = feh_file_info_preload(filelist);
 		if (!gib_list_length(filelist))

--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -378,16 +378,22 @@ void slideshow_change_image(winwidget winwid, int change, int render)
 			tzoom = winwid->zoom;
 		}
 
-		if ((winwidget_loadimage(winwid, FEH_FILE(current_file->data)))
-		    != 0) {
+		if (winwidget_loadimage(winwid, FEH_FILE(current_file->data))) {
+			unsigned int w = gib_imlib_image_get_width(winwid->im);
+			unsigned int h = gib_imlib_image_get_height(winwid->im);
+			if (opt.min_width || opt.min_height || (opt.max_width != UINT_MAX) || (opt.max_height != UINT_MAX)) {
+				if (w < opt.min_width || w > opt.max_width || h < opt.min_height || h > opt.max_height) {
+					last = current_file;
+					continue;
+				}
+			}
 			winwid->mode = MODE_NORMAL;
 			winwid->file = current_file;
-			if ((winwid->im_w != gib_imlib_image_get_width(winwid->im))
-			    || (winwid->im_h != gib_imlib_image_get_height(winwid->im)))
+			if ((winwid->im_w != (int)w) || (winwid->im_h != (int)h))
 				winwid->had_resize = 1;
 			winwidget_reset_image(winwid);
-			winwid->im_w = gib_imlib_image_get_width(winwid->im);
-			winwid->im_h = gib_imlib_image_get_height(winwid->im);
+			winwid->im_w = w;
+			winwid->im_h = h;
 			if (opt.keep_zoom_vp) {
 				/* put back in: */
 				winwid->mode = tmode;


### PR DESCRIPTION
This will (by default) check the image dimension on-the-fly, but you can still do it beforehand by specifying the preload flag.

Fixes: #164