### PR TITLE
Add natural sort of (version) numbers

### DIFF
--- a/src/feh.h
+++ b/src/feh.h
@@ -27,6 +27,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef FEH_H
 #define FEH_H
 
+#define _GNU_SOURCE
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xatom.h>

--- a/src/filelist.c
+++ b/src/filelist.c
@@ -399,12 +399,18 @@ void feh_file_dirname(char *dst, feh_file * f, int maxlen)
 
 int feh_cmp_filename(void *file1, void *file2)
 {
-	return(strcmp(FEH_FILE(file1)->filename, FEH_FILE(file2)->filename));
+	if (!opt.version_sort)
+		return(strcmp(FEH_FILE(file1)->filename, FEH_FILE(file2)->filename));
+	else
+		return(strverscmp(FEH_FILE(file1)->filename, FEH_FILE(file2)->filename));
 }
 
 int feh_cmp_name(void *file1, void *file2)
 {
-	return(strcmp(FEH_FILE(file1)->name, FEH_FILE(file2)->name));
+	if (!opt.version_sort)
+		return(strcmp(FEH_FILE(file1)->name, FEH_FILE(file2)->name));
+	else
+		return(strverscmp(FEH_FILE(file1)->name, FEH_FILE(file2)->name));
 }
 
 int feh_cmp_dirname(void *file1, void *file2)
@@ -413,8 +419,13 @@ int feh_cmp_dirname(void *file1, void *file2)
 	int cmp;
 	feh_file_dirname(dir1, FEH_FILE(file1), PATH_MAX);
 	feh_file_dirname(dir2, FEH_FILE(file2), PATH_MAX);
-	if ((cmp = strcmp(dir1, dir2)) != 0)
-		return(cmp);
+	if (!opt.version_sort) {
+		if ((cmp = strcmp(dir1, dir2)) != 0)
+			return(cmp);
+	} else {
+		if ((cmp = strverscmp(dir1, dir2)) != 0)
+			return(cmp);
+	}
 	return(feh_cmp_name(file1, file2));
 }
 

--- a/src/help.raw
+++ b/src/help.raw
@@ -52,6 +52,7 @@ OPTIONS
                            name, filename, mtime, width, height, pixels, size,
                            or format
  -n, --reverse             Reverse sort order
+     --version-sort        Natural sort of (version) numbers within text
  -A, --action [;]ACTION    Specify action to perform when pressing <return>.
                            Executed by /bin/sh, may contain FORMAT SPECIFIERS
                            reloads image with \";\", switches to next otherwise

--- a/src/options.c
+++ b/src/options.c
@@ -412,6 +412,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		{"insecure"      , 0, 0, 240},
 		{"no-recursive"  , 0, 0, 241},
 		{"cache-size"    , 1, 0, 243},
+		{"version-sort"  , 0, 0, 246},
 		{0, 0, 0, 0}
 	};
 	int optch = 0, cmdx = 0;
@@ -781,6 +782,9 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 				opt.cache_size = 0;
 			if (opt.cache_size > 2048)
 				opt.cache_size = 2048;
+			break;
+		case 246:
+			opt.version_sort = 1;
 			break;
 		default:
 			break;

--- a/src/options.h
+++ b/src/options.h
@@ -103,6 +103,7 @@ struct __fehoptions {
 	unsigned int thumb_redraw;
 	double reload;
 	int sort;
+	int version_sort;
 	int debug;
 	int geom_flags;
 	int geom_x;


### PR DESCRIPTION
Adds a new option `--version-sort` similar to `ls -v`.

Closes: https://github.com/derf/feh/issues/344

@derf, please let me know if you dislike the current solution, which is built around `strverscmp` which requires `#define _GNU_SOURCE`.