### PR TITLE
feh.1: Silence mandoc warnings

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -13,7 +13,7 @@
 .
 .Nm
 .Op Ar options
-.Op Ar files No | Ar directories No | Ar URLs ...
+.Op Ar files | Ar directories | Ar URLs ...
 .
 .
 .Sh VERSION
@@ -176,7 +176,7 @@ after
 executing the action.
 .
 If
-.No [ Ar title ]
+.Ar [ title ]
 is specified
 .Pq note the literal Qo \&[ Qc and Qo ] Qc ,
 .Cm --draw-actions
@@ -384,7 +384,7 @@ When combined with
 this option only affects images opened from the thumbnail overview.
 The thumbnail list itself will still be windowed.
 .
-.It Cm -g , --geometry Ar width Cm x Ar height No | Cm + Ar x Cm + Ar y | Ar width Cm x Ar height Cm + Ar x Cm + Ar y
+.It Cm -g , --geometry Ar width Cm x Ar height | Cm + Ar x Cm + Ar y | Ar width Cm x Ar height Cm + Ar x Cm + Ar y
 .
 Limit (and don't change) the window size.
 Takes an X-style geometry
@@ -782,7 +782,7 @@ on index 1 black/white, use
 .Qq --xinerama-index 0
 when setting the wallpaper.
 .
-.It Cm --zoom Ar percent No | Cm max No | Cm fill
+.It Cm --zoom Ar percent | Cm max | Cm fill
 .
 Zoom images by
 .Ar percent
@@ -820,7 +820,7 @@ When drawing thumbnails onto the background, set their transparency level to
 .Ar int
 .Pq 0 - 255 .
 .
-.It Cm -b , --bg Ar file No | Cm trans
+.It Cm -b , --bg Ar file | Cm trans
 .
 Use
 .Ar file


### PR DESCRIPTION
This fixes the following mandoc warnings.
```
man -Tlint feh
```
```
WARNING: skipping empty macro: No
```
```
skipping empty macro
  (mdoc) The indicated macro has no arguments and hence no effect.
```
https://man.openbsd.org/mandoc.1
```
man: /tmp/man1/feh.1:16:14: WARNING: skipping empty macro: No
man: /tmp/man1/feh.1:16:34: WARNING: skipping empty macro: No
man: /tmp/man1/feh.1:179:2: WARNING: skipping empty macro: No
man: /tmp/man1/feh.1:387:48: WARNING: skipping empty macro: No
man: /tmp/man1/feh.1:785:26: WARNING: skipping empty macro: No
man: /tmp/man1/feh.1:785:38: WARNING: skipping empty macro: No
man: /tmp/man1/feh.1:823:26: WARNING: skipping empty macro: No
```
As the warning suggests, these seem to have no effect and are just ignored. I at least did not notice any difference upon removing them.