### PR TITLE
feh.1: Silence mandoc warnings

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -1308,7 +1308,7 @@ without any keys unbinds it (i.e. the default bindings are removed).
 .
 .Pp
 .
-.Em Note :
+.Em Note:\&
 Do not use the same keybinding for multiple actions.
 When binding an action to a new key
 .Pq or mouse button ,
@@ -1480,7 +1480,7 @@ See
 .Xr jpegtran 1
 for more about lossless JPEG rotation.
 .
-.Em Note:
+.Em Note:\&
 .Nm
 assumes that this feature is used to normalize image orientation.
 For JPEG images, it will unconditionally set the EXIF orientation
@@ -1657,7 +1657,7 @@ looks like
 .
 .Pp
 .
-.Em Note :
+.Em Note:\&
 Do not use the same button for multiple actions.
 .Nm
 does not check for conflicting bindings, so their behaviour is undefined.
@@ -1893,8 +1893,6 @@ section.
 .
 .
 .Sh BUGS
-.
-.Pp
 .
 On systems with giflib 5.1.2,
 .Nm


### PR DESCRIPTION
There are two warnings here.

1. This is fixed by adding a zero-width space (`\&`) so that the trailing delimiter character (`:`) is no longer at the end. This also adds this to a few other similar examples. The man page should render the same after this change.
2. Removed an extra `.Pp` macro as suggested by the warning, this does not change how the man page renders.
```
man -Tlint feh
```
```
STYLE: no blank before trailing delimiter: Em Note:
WARNING: skipping paragraph macro: Pp after Sh
```
```
no blank before trailing delimiter
  (mdoc) The last argument of a macro that supports trailing
  delimiter arguments is longer than one byte and ends with a
  trailing delimiter. Consider inserting a blank such that the
  delimiter becomes a separate argument, thus moving it out of
  the scope of the macro.
```
```
skipping paragraph macro
  In mdoc(7) documents, this happens

    - at the beginning and end of sections and subsections
    - right before non-compact lists and displays
    - at the end of items in non-column, non-compact lists
    - and for multiple consecutive paragraph macros.

  In man(7) documents, it happens

    - for empty P, PP, and LP macros
    - for IP macros having neither head nor body arguments
    - for br or sp right after SH or SS
```
  https://man.openbsd.org/mandoc.1
```
  man: feh.1:1483:9: STYLE: no blank before trailing delimiter: Em Note:
  man: feh.1:1897:2: WARNING: skipping paragraph macro: Pp after Sh
```