### PR TITLE
Add an option to disable click to advance

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -219,8 +219,13 @@ static void feh_event_handle_ButtonPress(XEvent * ev)
 
 	} else if (feh_is_bb(EVENT_pan, button, state)) {
 		D(("Next button, but could be pan mode\n"));
-		opt.mode = MODE_NEXT;
-		winwid->mode = MODE_NEXT;
+		if (opt.disable_click_to_advance) {
+			opt.mode = MODE_PAN;
+			winwid->mode = MODE_PAN;
+		} else {
+			opt.mode = MODE_NEXT;
+			winwid->mode = MODE_NEXT;
+		}
 		D(("click offset is %d,%d\n", ev->xbutton.x, ev->xbutton.y));
 		winwid->click_offset_x = ev->xbutton.x - winwid->im_x;
 		winwid->click_offset_y = ev->xbutton.y - winwid->im_y;

--- a/src/options.c
+++ b/src/options.c
@@ -418,6 +418,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		{"conversion-timeout" , 1, 0, 245},
 		{"version-sort"  , 0, 0, 246},
 		{"offset"        , 1, 0, 247},
+		{"disable_click_to_advance", 0, 0, 248},
 		{0, 0, 0, 0}
 	};
 	int optch = 0, cmdx = 0;
@@ -794,6 +795,9 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		case 247:
 			opt.offset_flags = XParseGeometry(optarg, &opt.offset_x,
 					&opt.offset_y, (unsigned int *)&discard, (unsigned int *)&discard);
+			break;
+		case 248:
+			opt.disable_click_to_advance = 1;
 			break;
 		default:
 			break;

--- a/src/options.h
+++ b/src/options.h
@@ -75,6 +75,7 @@ struct __fehoptions {
 	unsigned char keep_zoom_vp;
 	unsigned char insecure_ssl;
 	unsigned char filter_by_dimensions;
+	unsigned char disable_click_to_advance;
 
 	char *output_file;
 	char *output_dir;


### PR DESCRIPTION
This allows the user to decouple the pan modifier from the next image modifier.

Closes: #411

PS: `disable_click_to_advance` might not be the best name for the new option