### PR TITLE
Antialias rotated images (even at native resolution)

### DIFF
--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -520,7 +520,7 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 	D(("sx: %d sy: %d sw: %d sh: %d dx: %d dy: %d dw: %d dh: %d zoom: %f\n",
 	   sx, sy, sw, sh, dx, dy, dw, dh, winwid->zoom));
 
-	if ((winwid->zoom != 1.0) && !force_alias && !winwid->force_aliasing)
+	if ((winwid->zoom != 1.0 || winwid->has_rotated) && !force_alias && !winwid->force_aliasing)
 		antialias = 1;
 
 	D(("winwidget_render(): winwid->im_angle = %f\n", winwid->im_angle));


### PR DESCRIPTION
This fixes part 3 of #310:
> when image is rotated at native resolution (100% zoom), anti-aliasing seems to be not applied; this should probably be fixed