### PR TITLE
Add an option to disable inplace edit

### DIFF
--- a/src/imlib.c
+++ b/src/imlib.c
@@ -1192,6 +1192,22 @@ void feh_edit_inplace(winwidget w, int op)
 	if (!w->file || !w->file->data || !FEH_FILE(w->file->data)->filename)
 		return;
 
+	if (opt.no_inplace_edit) {
+		imlib_context_set_image(w->im);
+		if (op == INPLACE_EDIT_FLIP)
+			imlib_image_flip_vertical();
+		else if (op == INPLACE_EDIT_MIRROR)
+			imlib_image_flip_horizontal();
+		else {
+			imlib_image_orientate(op);
+			tmp = w->im_w;
+			FEH_FILE(w->file->data)->info->width = w->im_w = w->im_h;
+			FEH_FILE(w->file->data)->info->height = w->im_h = tmp;
+		}
+		winwidget_render_image(w, 1, 0);
+		return;
+	}
+
 	if (!strcmp(gib_imlib_image_format(w->im), "jpeg") &&
 			!path_is_url(FEH_FILE(w->file->data)->filename)) {
 		feh_edit_inplace_lossless(w, op);

--- a/src/options.c
+++ b/src/options.c
@@ -418,6 +418,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		{"conversion-timeout" , 1, 0, 245},
 		{"version-sort"  , 0, 0, 246},
 		{"offset"        , 1, 0, 247},
+		{"no-inplace-edit", 0, 0, 248},
 		{0, 0, 0, 0}
 	};
 	int optch = 0, cmdx = 0;
@@ -794,6 +795,9 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		case 247:
 			opt.offset_flags = XParseGeometry(optarg, &opt.offset_x,
 					&opt.offset_y, (unsigned int *)&discard, (unsigned int *)&discard);
+			break;
+		case 248:
+			opt.no_inplace_edit = 1;
 			break;
 		default:
 			break;

--- a/src/options.h
+++ b/src/options.h
@@ -105,6 +105,7 @@ struct __fehoptions {
 	double reload;
 	int sort;
 	int version_sort;
+	int no_inplace_edit;
 	int debug;
 	int geom_enabled;
 	int geom_flags;


### PR DESCRIPTION
This new `--no-inplace-edit` option makes the image manipulations done by <, >, _, | transient.
If you ask me, this should be the default setting.

> [feh does support rotation without changing the file.
...
However it does not snap to 90° angles and there are no keyboard shortcuts for it. Keyboard shortcuts for this type of rotation (in 90° steps) will be added.](https://github.com/derf/feh/issues/86#issuecomment-14922457)

Closes: https://github.com/derf/feh/issues/167
Possibly closes: https://github.com/derf/feh/issues/86
This fixes part 1 of: https://github.com/derf/feh/issues/310

@teleshoes suggested to additionally add a `--rotate=[90;180;270;EXIF]` option.