### PR TITLE
Allow setting the X11 class hint as an option.

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -303,6 +303,13 @@ zero causes
 to try indefinitely.
 Negative values restore the default by disabling conversion altogether.
 .
+.It Cm --class Ar class
+.
+Set the X11 class hint to
+.Ar class .
+.
+Default: feh
+.
 .It Cm -L , --customlist Ar format
 .
 Don't display images, print image info according to
@@ -320,7 +327,7 @@ Draw the defined actions and what they do at the top-left of the image.
 .Pq optional feature, $MAN_EXIF$ in this build
 display some EXIF information in the bottom left corner, similar to using
 .Cm --info
-with exiv2 / exifgrep .
+with exiv2 / exifgrep.
 .
 .It Cm -d , --draw-filename
 .
@@ -330,7 +337,7 @@ Draw the file name at the top-left of the image.
 .
 Show overlay texts
 .Pq as created by Cm --draw-filename No et al
-on a semi-transparent background to improve their readability
+on a semi-transparent background to improve their readability.
 .
 .It Cm --edit
 .

--- a/src/options.c
+++ b/src/options.c
@@ -430,6 +430,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 #ifdef HAVE_INOTIFY
 		{"auto-reload"   , 0, 0, 248},
 #endif
+		{"class"         , 1, 0, 249},
 		{0, 0, 0, 0}
 	};
 	int optch = 0, cmdx = 0;
@@ -823,6 +824,9 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 			opt.auto_reload = 1;
 			break;
 #endif
+		case 249:
+			opt.x11_class = estrdup(optarg);
+			break;
 		default:
 			break;
 		}

--- a/src/options.h
+++ b/src/options.h
@@ -128,6 +128,7 @@ struct __fehoptions {
 	int zoom_mode;
 	unsigned char adjust_reload;
 	int xinerama_index;
+	char *x11_class;
 
 	/* signed in case someone wants to invert scrolling real quick */
 	int scroll_step;

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -305,7 +305,7 @@ void winwidget_create_window(winwidget ret, int w, int h)
 	winwidget_update_title(ret);
 	xch = XAllocClassHint();
 	xch->res_name = "feh";
-	xch->res_class = "feh";
+	xch->res_class = opt.x11_class ? opt.x11_class : "feh";
 	XSetClassHint(disp, ret->win, xch);
 	XFree(xch);
 


### PR DESCRIPTION
Fixes https://github.com/derf/feh/issues/180 I guess. Not sure that window ID is even possible, but the class hint is fairly easy. `--class` is what other tools call it too, so I went with it (no short argument though, I doubt that's necessary).