### PR TITLE
Add missing EXIF rotations.

### DIFF
--- a/src/gib_imlib.c
+++ b/src/gib_imlib.c
@@ -717,3 +717,15 @@ void gib_imlib_image_orientate(Imlib_Image im, int orientation)
   imlib_context_set_image(im);
   imlib_image_orientate(orientation);
 }
+
+void gib_imlib_image_flip_horizontal(Imlib_Image im)
+{
+  imlib_context_set_image(im);
+  imlib_image_flip_horizontal();
+}
+
+void gib_imlib_image_flip_vertical(Imlib_Image im)
+{
+  imlib_context_set_image(im);
+  imlib_image_flip_vertical();
+}

--- a/src/gib_imlib.h
+++ b/src/gib_imlib.h
@@ -181,6 +181,8 @@ void gib_imlib_parse_color(char *col, int *r, int *g, int *b, int *a);
 void gib_imlib_parse_fontpath(char *path);
 Imlib_Font gib_imlib_load_font(char *name);
 void gib_imlib_image_orientate(Imlib_Image im, int orientation);
+void gib_imlib_image_flip_horizontal(Imlib_Image im);
+void gib_imlib_image_flip_vertical(Imlib_Image im);
 
 #ifdef __cplusplus
 }

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -294,10 +294,22 @@ int feh_load_image(Imlib_Image * im, feh_file * file)
 	}
 	file->ed = exifData;
 
-	if (orientation == 3)
+	if (orientation == 2)
+		gib_imlib_image_flip_horizontal(*im);
+	else if (orientation == 3)
 		gib_imlib_image_orientate(*im, 2);
+	else if (orientation == 4)
+		gib_imlib_image_flip_vertical(*im);
+	else if (orientation == 5) {
+		gib_imlib_image_orientate(*im, 3);
+		gib_imlib_image_flip_vertical(*im);
+	}
 	else if (orientation == 6)
 		gib_imlib_image_orientate(*im, 1);
+	else if (orientation == 7) {
+		gib_imlib_image_orientate(*im, 3);
+		gib_imlib_image_flip_horizontal(*im);
+	}
 	else if (orientation == 8)
 		gib_imlib_image_orientate(*im, 3);
 #endif


### PR DESCRIPTION
Fixes <https://github.com/derf/feh/issues/397> I think.

Tested on all files from <https://github.com/recurser/exif-orientation-examples>: With this patch they all look identical (when `--auto-rotate` is on), without it only some of them do.