### PR TITLE
Add --rotate option

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -208,11 +208,26 @@ Example usage:
 .
 Extra actions which can be set and triggered using the appropriate number key.
 .
+.It Cm --rotate Cm right | Cm left | Cm 180
+.
+Rotate all loaded images
+.Cm right ,
+.Cm left ,
+or
+.Cm 180
+degrees.
+Useful for keeping wallpaper oriented correctly when used in conjunction with an
+autorotate program on a tablet or 2-in-1.
+Cannot be used with
+.Cm --auto-rotate .
+.
 .It Cm --auto-rotate
 .
 .Pq optional feature, $MAN_EXIF$ in this build
 Automatically rotate images based on EXIF data.
 Does not alter the image files.
+Cannot be used with
+.Cm --rotate .
 .
 .It Cm -Z , --auto-zoom
 .
@@ -1078,6 +1093,15 @@ You may also use
 to use
 .Nm
 as a background setter for a specific screen.
+.
+.Pp
+.
+Use
+.Cm --rotate
+.Pq Cm right , Cm left , No or Cm 180
+to keep the wallpaper oriented correctly when using
+.Cm feh
+in conjunction with an autorotate program on a tablet or 2-in-1.
 .
 .Bl -tag -width indent
 .

--- a/src/help.raw
+++ b/src/help.raw
@@ -36,7 +36,12 @@ OPTIONS
      --draw-tinted         Show overlay texts on semi-transparent background
      --draw-exif           Show some Exif information (if compiled with exif=1)
      --edit                Make flip/rotation keys flip/rotate the underlying file
+     --rotate ORIENTATION  Rotate all images \"right\", \"left\", or \"180\".
+                           Useful for keeping wallpaper oriented correctly when used in
+                           conjunction with an autorotate program on a tablet or 2-in-1.
+                           Cannot be used with --auto-rotate.
      --auto-rotate         Rotate images according to Exif info (if compiled with exif=1)
+                           Cannot be used with --rotate.
  -^, --title TITLE         Set window title (see FORMAT SPECIFIERS)
  -D, --slideshow-delay NUM Set delay between automatically changing slides
      --on-last-slide quit  Exit after one loop through the slide show

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -284,35 +284,40 @@ int feh_load_image(Imlib_Image * im, feh_file * file)
 	imlib_context_set_image(*im);
 	imlib_image_set_changes_on_disk();
 
+	if (opt.rotate) {
+		gib_imlib_image_orientate(*im, opt.rotate);
+	}
 #ifdef HAVE_LIBEXIF
-	int orientation = 0;
-	ExifData *exifData = exif_data_new_from_file(file->filename);
-	if (exifData) {
-		ExifByteOrder byteOrder = exif_data_get_byte_order(exifData);
-		ExifEntry *exifEntry = exif_data_get_entry(exifData, EXIF_TAG_ORIENTATION);
-		if (exifEntry && opt.auto_rotate)
-			orientation = exif_get_short(exifEntry->data, byteOrder);
-	}
-	file->ed = exifData;
+	else if (opt.auto_rotate) {
+		int orientation = 0;
+		ExifData *exifData = exif_data_new_from_file(file->filename);
+		if (exifData) {
+			ExifByteOrder byteOrder = exif_data_get_byte_order(exifData);
+			ExifEntry *exifEntry = exif_data_get_entry(exifData, EXIF_TAG_ORIENTATION);
+			if (exifEntry)
+				orientation = exif_get_short(exifEntry->data, byteOrder);
+		}
+		file->ed = exifData;
 
-	if (orientation == 2)
-		gib_imlib_image_flip_horizontal(*im);
-	else if (orientation == 3)
-		gib_imlib_image_orientate(*im, 2);
-	else if (orientation == 4)
-		gib_imlib_image_flip_vertical(*im);
-	else if (orientation == 5) {
-		gib_imlib_image_orientate(*im, 3);
-		gib_imlib_image_flip_vertical(*im);
+		if (orientation == 2)
+			gib_imlib_image_flip_horizontal(*im);
+		else if (orientation == 3)
+			gib_imlib_image_orientate(*im, 2);
+		else if (orientation == 4)
+			gib_imlib_image_flip_vertical(*im);
+		else if (orientation == 5) {
+			gib_imlib_image_orientate(*im, 3);
+			gib_imlib_image_flip_vertical(*im);
+		}
+		else if (orientation == 6)
+			gib_imlib_image_orientate(*im, 1);
+		else if (orientation == 7) {
+			gib_imlib_image_orientate(*im, 3);
+			gib_imlib_image_flip_horizontal(*im);
+		}
+		else if (orientation == 8)
+			gib_imlib_image_orientate(*im, 3);
 	}
-	else if (orientation == 6)
-		gib_imlib_image_orientate(*im, 1);
-	else if (orientation == 7) {
-		gib_imlib_image_orientate(*im, 3);
-		gib_imlib_image_flip_horizontal(*im);
-	}
-	else if (orientation == 8)
-		gib_imlib_image_orientate(*im, 3);
 #endif
 
 	D(("Loaded ok\n"));

--- a/src/options.c
+++ b/src/options.c
@@ -406,6 +406,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		{"bg-max"        , 0, 0, 219},
 		{"no-jump-on-resort", 0, 0, 220},
 		{"edit"          , 0, 0, 221},
+		{"rotate"        , 1, 0, 222},
 #ifdef HAVE_LIBEXIF
 		{"draw-exif"     , 0, 0, 223},
 		{"auto-rotate"   , 0, 0, 242},
@@ -735,6 +736,14 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		case 221:
 			opt.edit = 1;
 			break;
+		case 222:
+			if (!strcmp("right", optarg))
+				opt.rotate = 1;
+			else if (!strcmp("180", optarg))
+				opt.rotate = 2;
+			else if (!strcmp("left", optarg))
+				opt.rotate = 3;
+			break;
 #ifdef HAVE_LIBEXIF
 		case 223:
 			opt.draw_exif = 1;
@@ -874,6 +883,12 @@ static void check_options(void)
 	if (opt.loadables && opt.unloadables) {
 		eprintf("You cannot combine --loadable with --unloadable");
 	}
+
+#ifdef HAVE_LIBEXIF
+	if (opt.rotate && opt.auto_rotate) {
+		eprintf("You cannot combine --rotate with --auto_rotate");
+	}
+#endif
 
 	return;
 }

--- a/src/options.h
+++ b/src/options.h
@@ -54,6 +54,7 @@ struct __fehoptions {
 	unsigned char jump_on_resort;
 	unsigned char full_screen;
 	unsigned char draw_filename;
+	int rotate;
 #ifdef HAVE_LIBEXIF
 	unsigned char draw_exif;
 	unsigned char auto_rotate;


### PR DESCRIPTION
"Useful for keeping orientation of wallpaper correct when feh is used
in conjunction with an autorotate program on a tablet or 2-in-1."

I set the wallpaper on my tablet with feh. When I turn the tablet, my autorotate program rotates everything, including the wallpaper - which then tiles in an ugly way. Now my autorotate program can rotate my window manager and afterwards call feh with this option to rotate the wallpaper backwards, so that it looks as if the wallpaper _hasn't_ rotated with my window manager - keeping everything pretty.

Intended for use with the wallpaper options like --bg-fill, but works with other feh modes too.
Currently cannot be used with --auto-rotate, but that could probably be changed if anyone needs it.