### PR TITLE
Update "src/signals.h"

### DIFF
--- a/src/signals.h
+++ b/src/signals.h
@@ -27,5 +27,5 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define SIGNALS_H
 
 void setup_signal_handlers();
-volatile extern int sig_exit;
+extern volatile int sig_exit;
 #endif


### PR DESCRIPTION
Use "extern volatile" instead of "volatile extern" to avoid "gcc" warning "'extern' is not at beginning of declaration [-Wold-style-declaration]".