### PR TITLE
Check that window geometry is accurate

### DIFF
--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -820,6 +820,8 @@ void winwidget_resize(winwidget winwid, int w, int h, int force_resize)
 		winwid->had_resize = 1;
 		XFlush(disp);
 
+		winwidget_get_geometry(winwid, NULL);
+
 		if (force_resize && (opt.geom_flags & (WidthValue | HeightValue))
 				&& (winwid->type != WIN_TYPE_THUMBNAIL)) {
 			opt.geom_w = winwid->w;
@@ -1059,8 +1061,11 @@ void winwidget_get_geometry(winwidget winwid, int *rect)
 {
 	unsigned int bw, bp;
 	Window child;
+
+	int inner_rect[4];
+
 	if (!rect)
-		return;
+		rect = inner_rect;
 
 	XGetGeometry(disp, winwid->win, &root, &(rect[0]), &(rect[1]), (unsigned
 				int *)&(rect[2]), (unsigned int *)&(rect[3]), &bw, &bp);

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -721,6 +721,8 @@ void winwidget_show(winwidget winwid)
 		/* wait for the window to map */
 		D(("Waiting for window to map\n"));
 		XMaskEvent(disp, StructureNotifyMask, &ev);
+		winwidget_get_geometry(winwid, NULL);
+
 		/* Unfortunately, StructureNotifyMask does not only mask
 		 * the events of type MapNotify (which we want to mask here)
 		 * but also such of type ConfigureNotify (and others, see


### PR DESCRIPTION
Sometimes, X11 won't actually resize a window to the provided size with `X11ResizeWindow`, like if the window manager forces it to stay maximized. This pull request ensures the window's width and height properties are what X11 actually has.

This fixes #446 - KDE (in my case) was sending ConfigureNotify events with the maximized width and height. Feh thought the window's width and height were what it had calculated, instead of what X11 forced, and decided to rerender which caused a flash.