### PR TITLE
Add '--skip REGEX' to skip matching files to list

### DIFF
--- a/src/filelist.c
+++ b/src/filelist.c
@@ -46,6 +46,9 @@ feh_file *feh_file_new(char *filename)
 	feh_file *newfile;
 	char *s;
 
+	if(opt.filter.allocated != 0 && !regexec(&opt.filter, filename, 0, NULL, 0))
+		return NULL;
+
 	newfile = (feh_file *) emalloc(sizeof(feh_file));
 	newfile->caption = NULL;
 	newfile->filename = estrdup(filename);

--- a/src/gib_list.c
+++ b/src/gib_list.c
@@ -134,6 +134,9 @@ gib_list_add_front(gib_list * root, void *data)
 {
    gib_list *l;
 
+   if (data == NULL)
+      return(root);
+
    l = gib_list_new();
    l->next = root;
    l->data = data;

--- a/src/help.raw
+++ b/src/help.raw
@@ -20,6 +20,7 @@ OPTIONS
  -g, --geometry WxH[+X+Y]  Limit the window size to DIMENSION[+OFFSET]
  -f, --filelist FILE       Load/save images from/to the FILE filelist
  -|, --start-at FILENAME   Start at FILENAME in the filelist
+     --skip REGEX          Skip files in file list matching with REGEX
  -p, --preload             Remove unloadable files from the internal filelist
                            before attempting to display anything
  -., --scale-down          Automatically scale down images to fit screen size

--- a/src/options.c
+++ b/src/options.c
@@ -76,6 +76,7 @@ void init_parse_options(int argc, char **argv)
 #ifdef HAVE_INOTIFY
 	opt.auto_reload = 1;
 #endif				/* HAVE_INOTIFY */
+	opt.filter.allocated = 0;
 
 	feh_getopt_theme(argc, argv);
 
@@ -430,6 +431,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 #ifdef HAVE_INOTIFY
 		{"auto-reload"   , 0, 0, 248},
 #endif
+		{"skip"          , 1, 0, 249},
 		{0, 0, 0, 0}
 	};
 	int optch = 0, cmdx = 0;
@@ -823,6 +825,12 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 			opt.auto_reload = 1;
 			break;
 #endif
+
+		case 249:
+			if(regcomp(&opt.filter, optarg, 0)){
+				weprintf("Invalid skip REGEX. Disabling...\n");
+			}
+			break;
 		default:
 			break;
 		}

--- a/src/options.h
+++ b/src/options.h
@@ -27,6 +27,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef OPTIONS_H
 #define OPTIONS_H
 
+#include<regex.h>
+
 enum on_last_slide_action {
 	ON_LAST_SLIDE_RESUME = 0,
 	ON_LAST_SLIDE_QUIT,
@@ -104,6 +106,7 @@ struct __fehoptions {
 	char *start_list_at;
 	char *info_cmd;
 	char *index_info;
+	regex_t filter;
 
 	int force_aliasing;
 	int thumb_w;


### PR DESCRIPTION
The new option '--skip REGEX' enables the user to
skip files matching the REGEX to be added to the
final file list. For example, this is useful if you
want to create a slideshow on a folder with suppressing
raw image files, such as '\.CR2$'.