### PR TITLE
warnings: fix snprintf destination buffer sizes

### DIFF
--- a/src/filelist.c
+++ b/src/filelist.c
@@ -634,7 +634,7 @@ char *feh_absolute_path(char *path)
 {
 	char cwd[PATH_MAX];
 	char fullpath[PATH_MAX];
-	char temp[PATH_MAX];
+	char temp[PATH_MAX + 2];
 	char *ret;
 
 	if (!path)

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -254,7 +254,7 @@ void feh_wm_set_bg(char *fil, Imlib_Image im, int centered, int scaled,
 	char bgname[20];
 	int num = (int) random();
 	char bgfil[4096];
-	char sendbuf[4096];
+	char sendbuf[PATH_MAX + 128];
 
 	/*
 	 * TODO this re-implements mkstemp (badly). However, it is only needed


### PR DESCRIPTION
The `sendbuf` buffer is a bit overlong here, but is a nice round number
to use for now.