### PR TITLE
add option 'a' to show play/paused information in slideshow mode

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -1204,6 +1204,10 @@ file
 .
 .Bl -tag -width indent
 .
+.It %a
+.
+Information about slideshow state (play/pause)
+.
 .It %f
 .
 Image path/filename

--- a/man/feh.pre
+++ b/man/feh.pre
@@ -1206,7 +1206,7 @@ file
 .
 .It %a
 .
-Information about slideshow state (play/pause)
+Information about slideshow state (playing/paused)
 .
 .It %f
 .

--- a/src/help.raw
+++ b/src/help.raw
@@ -124,7 +124,7 @@ INDEX MODE OPTIONS
                            font is specified, a title will not be printed
 
 FORMAT SPECIFIERS
- %a     information about slideshow state (play/pause)
+ %a     information about slideshow state (playing/paused)
  %f     image path/filename
  %F     image path/filename (shell-escaped)
  %g     window dimensions (\"width,height\") in pixels

--- a/src/help.raw
+++ b/src/help.raw
@@ -124,6 +124,7 @@ INDEX MODE OPTIONS
                            font is specified, a title will not be printed
 
 FORMAT SPECIFIERS
+ %a     information about slideshow state (play/pause)
  %f     image path/filename
  %F     image path/filename (shell-escaped)
  %g     window dimensions (\"width,height\") in pixels

--- a/src/keyevents.c
+++ b/src/keyevents.c
@@ -710,8 +710,8 @@ void feh_event_handle_generic(winwidget winwid, unsigned int state, KeySym keysy
 	}
 	else if (feh_is_kp(EVENT_toggle_pause, state, keysym, button)) {
 		slideshow_pause_toggle(winwid);
-		/* We need to reload the image to update the info string immediately. */
-		feh_reload_image(winwid, 0, 0);
+		/* We need to re-render the image to update the info string immediately. */
+		winwidget_render_image(winwid, 0, 0);
 	}
 	else if (feh_is_kp(EVENT_save_image, state, keysym, button)) {
 		slideshow_save_image(winwid);

--- a/src/keyevents.c
+++ b/src/keyevents.c
@@ -710,6 +710,8 @@ void feh_event_handle_generic(winwidget winwid, unsigned int state, KeySym keysy
 	}
 	else if (feh_is_kp(EVENT_toggle_pause, state, keysym, button)) {
 		slideshow_pause_toggle(winwid);
+		/* We need to reload the image to update the info string immediately. */
+		feh_reload_image(winwid, 0, 0);
 	}
 	else if (feh_is_kp(EVENT_save_image, state, keysym, button)) {
 		slideshow_save_image(winwid);

--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -397,14 +397,14 @@ char *feh_printf(char *str, feh_file * file, winwidget winwid)
 		if ((*c == '%') && (*(c+1) != '\0')) {
 			c++;
 			switch (*c) {
-	        case 'a':
-	           	if (opt.paused == 1) {
-	               strncat(ret, "pause", sizeof(ret) - strlen(ret) - 1);
-	            }
-	            else {
-	               strncat(ret, "play", sizeof(ret) - strlen(ret) - 1);
-	            }
-	            break;
+			case 'a':
+				if (opt.paused == 1) {
+				   strncat(ret, "pause", sizeof(ret) - strlen(ret) - 1);
+				}
+				else {
+				   strncat(ret, "play", sizeof(ret) - strlen(ret) - 1);
+				}
+				break;
 			case 'f':
 				if (file)
 					strncat(ret, file->filename, sizeof(ret) - strlen(ret) - 1);

--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -397,6 +397,14 @@ char *feh_printf(char *str, feh_file * file, winwidget winwid)
 		if ((*c == '%') && (*(c+1) != '\0')) {
 			c++;
 			switch (*c) {
+	        case 'a':
+	           	if (opt.paused == 1) {
+	               strncat(ret, "pause", sizeof(ret) - strlen(ret) - 1);
+	            }
+	            else {
+	               strncat(ret, "play", sizeof(ret) - strlen(ret) - 1);
+	            }
+	            break;
 			case 'f':
 				if (file)
 					strncat(ret, file->filename, sizeof(ret) - strlen(ret) - 1);

--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -399,10 +399,10 @@ char *feh_printf(char *str, feh_file * file, winwidget winwid)
 			switch (*c) {
 			case 'a':
 				if (opt.paused == 1) {
-				   strncat(ret, "pause", sizeof(ret) - strlen(ret) - 1);
+				   strncat(ret, "paused", sizeof(ret) - strlen(ret) - 1);
 				}
 				else {
-				   strncat(ret, "play", sizeof(ret) - strlen(ret) - 1);
+				   strncat(ret, "playing", sizeof(ret) - strlen(ret) - 1);
 				}
 				break;
 			case 'f':


### PR DESCRIPTION
I use feh to display image slideshows that can be toggled via remote. For long delays between images, I was missing a visual cue to tell whether the slideshow was running or paused.

This can now be achieved via the %a format specifier in the `--info` option.

I used 'a' because it was one of the few free letters, but if someone comes up with a more intuitive name, I am happy to change it.