### PR TITLE
Quit curl cleanly even if libcurl is old.

### DIFF
--- a/src/imlib.c
+++ b/src/imlib.c
@@ -542,7 +542,11 @@ static char *feh_magick_load_image(char *filename)
 
 #ifdef HAVE_LIBCURL
 
+#if LIBCURL_VERSION_NUM >= 0x072000 /* 07.32.0 */
 static int curl_quit_function(void *clientp,  curl_off_t dltotal,  curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow)
+#else
+static int curl_quit_function(void *clientp,  double dltotal,  double dlnow, double ultotal, double ulnow)
+#endif
 {
 	// ignore "unused parameter" warnings
 	(void)clientp;
@@ -617,6 +621,8 @@ static char *feh_http_load_image(char *url)
 			curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
 #if LIBCURL_VERSION_NUM >= 0x072000 /* 07.32.0 */
 			curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, curl_quit_function);
+#else
+			curl_easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, curl_quit_function);
 #endif
 			curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0);
 			if (opt.insecure_ssl) {


### PR DESCRIPTION
Building feh 3.3 on CentOS 7 x86_64 warns `curl_quit_function` in `imlib.c` is unused:

```
cc -g -O2 -Wall -Wextra -pedantic -std=c11 -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -DHAVE_LIBCURL -DHAVE_VERSCMP -DHAVE_LIBXINERAMA -DHAVE_LIBEXIF -DPREFIX=\"/usr/local\" -DPACKAGE=\"feh\" -DVERSION=\"3.3\"   -c -o imlib.o imlib.c
imlib.c:545:12: warning: ‘curl_quit_function’ defined but not used [-Wunused-function]
 static int curl_quit_function(void *clientp,  curl_off_t dltotal,  curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow)
            ^
```
The `curl_quit_function` code was added in response to pull [#435](https://github.com/derf/feh/pull/435)

In issue [#485](https://github.com/derf/feh/issues/485) a fellow CentOS 7 user had an error building feh because CentOS 7 is locked into an old version of libcurl. In the fix, a version guard was wrapped around the `curl_easy_setopt` call, but the rest of the code was unchanged.

Since I don't want to maintain a local build of libcurl, I looked at the curl docs and noticed there is an older callback which serves the same purpose: https://curl.haxx.se/libcurl/c/CURLOPT_PROGRESSFUNCTION.html

The difference between `PROGRESS` and `XFERINFO` is the callback's argument types, with `PROGRESS` using `double` and `XFERINFO` using `curl_off_t`: https://curl.haxx.se/libcurl/c/CURLOPT_XFERINFOFUNCTION.html

The callback's return value logic and use of `CURLOPT_NOPROGRESS` is the same.

For context, the latest libcurl RPM I'm getting from yum updates is `libcurl-7.29.0-54.el7_7.2.x86_64`. The "stable" versions of other distros may encounter similar issues. The CentOS 7 "End of Life" date is 2024-06-30 so you should hear the end of this by then, at least from us pesky CentOS users.