### PR TITLE
Enable re-using downloaded http cache

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -431,6 +431,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		{"auto-reload"   , 0, 0, 248},
 #endif
 		{"class"         , 1, 0, 249},
+		{"use-http-cache", 0, 0, 250},
 		{0, 0, 0, 0}
 	};
 	int optch = 0, cmdx = 0;
@@ -826,6 +827,9 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 #endif
 		case 249:
 			opt.x11_class = estrdup(optarg);
+			break;
+		case 250:
+			opt.use_http_cache = 1;
 			break;
 		default:
 			break;

--- a/src/options.h
+++ b/src/options.h
@@ -49,6 +49,7 @@ struct __fehoptions {
 	unsigned char aspect;
 	unsigned char stretch;
 	unsigned char keep_http;
+	unsigned char use_http_cache;
 	unsigned char borderless;
 	unsigned char randomize;
 	unsigned char jump_on_resort;


### PR DESCRIPTION
feh attempts to re-fetch each http source in a slideshow when going back and forth between images. This patch adds the flag `--use-http-cache`, enabling which allows feh to use the previously downloaded files.