### PR TITLE
Add windowid option to draw to an existing window

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -21,16 +21,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: APT
+        run: sudo apt-get -y update
       - name: Install Dependencies
-        run: sudo apt install build-essential libx11-dev libxt-dev libimlib2-dev libtest-command-perl libtest-simple-perl
+        run: sudo apt-get -y install build-essential libx11-dev libxt-dev libimlib2-dev libtest-command-perl libtest-simple-perl
       - name: Install libcurl
         if: matrix.curl
-        run: sudo apt install libcurl4-openssl-dev
+        run: sudo apt-get -y  install libcurl4-openssl-dev
       - name: Install libexif
         if: matrix.exif
-        run: sudo apt install libexif-dev
+        run: sudo apt-get -y  install libexif-dev
       - name: Install Xinerama
         if: matrix.xinerama
-        run: sudo apt install libxinerama-dev
+        run: sudo apt-get -y  install libxinerama-dev
       - name: Build and Test
         run: for inotify in 0 1; do for verscmp in 0 1; do make curl=${{ matrix.curl }} exif=${{ matrix.exif }} inotify=$inotify verscmp=$verscmp xinerama=${{ matrix.xinerama }} && make test && make clean; done; done

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,6 @@
-git HEAD
+Sat, 29 Aug 2020 08:49:08 +0200  Daniel Friesel <derf+feh@finalrewind.org>
+
+* Release v3.5
     * Enable --version-sort on systems without strverscmp support. This
       works by bundling the strverscmp of musl libc with feh and using it
       when feh is compiled without the verscmp flag (i.e., when the system

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+git HEAD
+    * Enable --version-sort on systems without strverscmp support. This
+      works by bundling the strverscmp of musl libc with feh and using it
+      when feh is compiled without the verscmp flag (i.e., when the system
+      libc does not provide the verscmp function). Patch by Tim van der Molen
+    * Add %a format specifier (slideshow state: "playing" / "paused")
+    * Fix crashes when combining --reload and --multiwindow
+
 Fri, 29 May 2020 23:52:35 +0200  Daniel Friesel <derf+feh@finalrewind.org>
 
 * Release v3.4.1

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+Sun, 06 Dec 2020 08:34:15 +0100  Daniel Friesel <derf+feh@finalrewind.org>
+
+* Release v3.6.1
+    * Fix excessive memory consumption when showing long-running slideshows
+      with thousands to tens of thousands of images and feh has been compiled
+      with exif=1 (see https://github.com/derf/feh/issues/553)
+    * Fix memory leak when showing long-running slideshows with relatively few
+      images and feh has been compiled with exif=1 (ibid.)
+    * Fix memory leak when reloading an image and feh has been compiled with
+      exif=1
+    * Fix memory leak in --draw-exif
+    * Fix memory leak when reloading HTTP files with --no-conversion-cache
+
 Mon, 30 Nov 2020 19:44:47 +0100  Daniel Friesel <derf+feh@finalrewind.org>
 * Release v3.6
     * Add flip and rotate options to the menu

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+Sat, 09 Jan 2021 12:28:06 +0100  Daniel Friesel <derf+feh@finalrewind.org>
+
+* Release v3.6.2
+    * Fix save_filelist not respecting --output-dir
+    * Fix file descriptor leak when attempting to load truncated image files.
+      The issue was introduced in v3.6.
+
 Sun, 06 Dec 2020 08:34:15 +0100  Daniel Friesel <derf+feh@finalrewind.org>
 
 * Release v3.6.1

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+Mon, 30 Nov 2020 19:44:47 +0100  Daniel Friesel <derf+feh@finalrewind.org>
+* Release v3.6
+    * Add flip and rotate options to the menu
+    * Improve unloadable image detection time (e.g. for large video files) by
+      checking a file's header before passing it to Imlib2. For rarely used
+      image formats, there is a very small chance that an image which could be
+      loaded by feh 3.5 is reported as unloadable by feh 3.6 due to this
+      change. Set FEH_SKIP_MAGIC=1 to bypass the header check in this case. See
+      <https://phab.enlightenment.org/T8739> and
+      <https://github.com/derf/feh/issues/505> for details.
+
+
 Sat, 29 Aug 2020 08:49:08 +0200  Daniel Friesel <derf+feh@finalrewind.org>
 
 * Release v3.5

--- a/man/feh.pre
+++ b/man/feh.pre
@@ -2113,23 +2113,11 @@ Please include the feh version
 steps to reproduce the bug and, if necessary, images to reproduce it.
 .
 .
-.Sh FUTURE PLANS
-.
-Plans for the following releases:
-.
-.Bl -bullet -compact
-.
-.It
-Make zoom options more intuitive
-.
-.El
-.
-.
 .Sh LICENSE
 .
 Copyright (C) 1999, 2000 by Paul Duncan.
-Copyright (C) 1999, 2000 by Tom Gilbert (and various contributors).
-Copyright (C) 2010-2020 by Daniel Friesel (and even more contributors).
+Copyright (C) 1999, 2000 by Tom Gilbert and contributors.
+Copyright (C) 2010-2020 by Daniel Friesel and contributors.
 .
 .Pp
 .
@@ -2171,5 +2159,5 @@ Tom Gilbert
 .
 .Pp
 .
-See also:
+Website:
 https://feh.finalrewind.org

--- a/man/feh.pre
+++ b/man/feh.pre
@@ -236,6 +236,10 @@ disabled by a preceding
 .Cm --reload=0
 option.
 .
+.Pp
+.
+Automatic reload is not supported in montage, index, or thumbnail mode.
+.
 .It Cm --auto-rotate
 .
 .Pq optional feature, $MAN_EXIF$ in this build
@@ -708,6 +712,7 @@ will continue to try loading it.
 .Pp
 .
 Setting this option causes inotify-based auto-reload to be disabled.
+Reload is not supported in montage, index, or thumbnail mode.
 .
 .It Cm -n , --reverse
 .

--- a/man/feh.pre
+++ b/man/feh.pre
@@ -29,13 +29,13 @@ Compile-time switches in this build:
 .Bl -bullet -compact
 .
 .It
-remote file support: libcurl $MAN_CURL$
+libcurl remote file support $MAN_CURL$
 .
 .It
 Xinerama multi-monitor support $MAN_XINERAMA$
 .
 .It
-builtin EXIF reader $MAN_EXIF$
+libexif builtin EXIF reader $MAN_EXIF$
 .
 .It
 inotify-based auto-reload of changed files $MAN_INOTIFY$

--- a/man/feh.pre
+++ b/man/feh.pre
@@ -218,7 +218,7 @@ Use format specifiers to refer to image info, see
 .Sx FORMAT SPECIFIERS
 for details.
 Example usage:
-.Qq feh -A Qo mv ~/images/%N Qc * .
+.Qq feh -A Qo mv %F ~/images/%N Qc * .
 .
 .It Cm --action1 No .. Cm --action9 Oo Ar flag Oc Ns Oo [ Ar title ] Oc Ns Ar action
 .

--- a/man/feh.pre
+++ b/man/feh.pre
@@ -920,10 +920,17 @@ comes before
 Note that this option only has an effect when a sort mode is set using
 .Cm --sort .
 .
-.It Cm --windowid Ar windowid
+.It Cm --window-id Ar windowid
 .
 Draw to an existing X11 window by its ID
 .Ar windowid .
+This option is intended for use with software such as xcreensaver or
+xsecurelock, which provide a window for other applications to draw into.
+Unexpected things will happen if you specify a window belonging to software
+which does not expect
+.Nm
+to draw into it or attempt to use options or keybindings which affect window
+attributes, such as full-screen mode.
 .
 .It Cm --xinerama-index Ar screen
 .

--- a/man/feh.pre
+++ b/man/feh.pre
@@ -162,6 +162,23 @@ Use
 .Cm --conversion-timeout Ar timeout
 with a non-negative value to enable support for these formats.
 .
+.Pp
+.
+As Imlib2 may take several seconds to determine whether it can load a file or
+not
+.Pq e.g. when attempting to open a large video ,
+.Nm
+checks each file's header before loading it.
+If it looks like an image, it is passed on to Imlib2, otherwise, it is
+assumed to be unloadable.
+This greatly improves performance when working in directories with mixed files
+.Pq i.e., directories which do not exclusively contain image files .
+If you think that Imlib2 can load a file which
+.Nm
+has determined to be likely not an image, set the environment variable
+.Qq FEH_SKIP_MAGIC
+to pass all files directly to Imlib2, bypassing the header check.
+The environment variable's value does not matter, it just needs to be set.
 .
 .Sh OPTIONS
 .

--- a/man/feh.pre
+++ b/man/feh.pre
@@ -13,6 +13,7 @@
 .
 .Nm
 .Op Ar options
+.Op Cm --
 .Op Ar files | Ar directories | Ar URLs ...
 .
 .

--- a/man/feh.pre
+++ b/man/feh.pre
@@ -671,7 +671,7 @@ Save files to
 .Ar directory
 when using
 .Cm --keep-http
-or the save_image command.
+or the save_image or save_filelist command.
 By default, files are saved in the current working directory.
 .
 .It Cm -p , --preload
@@ -1576,7 +1576,10 @@ will keep zoom and X, Y offset when switching images.
 .It L Bq save_filelist
 .
 Save the current filelist as
-.Qq feh_PID_ID_filelist
+.Qq feh_PID_ID_filelist .
+It is saved in the directory specified by
+.Cm --output-dir ,
+if set, and in the current working directory otherwise.
 .
 .It m Bq toggle_menu
 .
@@ -1612,7 +1615,10 @@ Useful for webcams
 .It s Bq save_image
 .
 Save the current image as
-.Qq feh_PID_ID_FILENAME
+.Qq feh_PID_ID_FILENAME .
+It is saved in the directory specified by
+.Cm --output-dir ,
+if set, and in the current working directory otherwise.
 .
 .It w Bq size_to_image
 .

--- a/src/feh.h
+++ b/src/feh.h
@@ -115,6 +115,14 @@ enum slide_change { SLIDE_NEXT, SLIDE_PREV, SLIDE_RAND, SLIDE_FIRST, SLIDE_LAST,
 	SLIDE_JUMP_PREV_DIR
 };
 
+enum feh_load_error {
+	LOAD_ERROR_IMLIB = 0,
+	LOAD_ERROR_IMAGEMAGICK,
+	LOAD_ERROR_CURL,
+	LOAD_ERROR_DCRAW,
+	LOAD_ERROR_MAGICBYTES
+};
+
 #define INPLACE_EDIT_FLIP   -1
 #define INPLACE_EDIT_MIRROR -2
 
@@ -172,7 +180,7 @@ void feh_display_status(char stat);
 void real_loadables_mode(int loadable);
 void feh_reload_image(winwidget w, int resize, int force_new);
 void feh_filelist_image_remove(winwidget winwid, char do_delete);
-void feh_imlib_print_load_error(char *file, winwidget w, Imlib_Load_Error err);
+void feh_print_load_error(char *file, winwidget w, Imlib_Load_Error err, enum feh_load_error feh_err);
 void slideshow_save_image(winwidget win);
 void feh_edit_inplace(winwidget w, int orientation);
 void feh_edit_inplace_lossless(winwidget w, int orientation);

--- a/src/filelist.c
+++ b/src/filelist.c
@@ -659,8 +659,17 @@ char *feh_absolute_path(char *path)
 void feh_save_filelist()
 {
 	char *tmpname;
+	char *base_dir = "";
 
-	tmpname = feh_unique_filename("", "filelist");
+	if (opt.output_dir) {
+		base_dir = estrjoin("", opt.output_dir, "/", NULL);
+	}
+
+	tmpname = feh_unique_filename(base_dir, "filelist");
+
+	if (opt.output_dir) {
+		free(base_dir);
+	}
 
 	if (opt.verbose)
 		fprintf(stderr, "saving filelist to filename '%s'\n", tmpname);

--- a/src/help.raw
+++ b/src/help.raw
@@ -100,7 +100,7 @@ OPTIONS
      --scroll-step COUNT   scroll COUNT pixels when movement key is pressed
      --cache-size NUM      imlib cache size in mebibytes (0 .. 2048)
      --auto-reload         automatically reload shown image if file was changed
-     --windowid            Draw to an existing X11 window by its ID
+     --window-id           Draw to an existing X11 window by its ID
 
 MONTAGE MODE OPTIONS
  -X, --ignore-aspect       Set thumbnail to specified width/height without

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -366,6 +366,13 @@ int feh_load_image(Imlib_Image * im, feh_file * file)
 
 			file->filename = real_filename;
 #ifdef HAVE_LIBEXIF
+			/*
+			 * if we're called from within feh_reload_image, file->ed is already
+			 * populated.
+			 */
+			if (file->ed) {
+				exif_data_unref(file->ed);
+			}
 			file->ed = exif_get_data(tmpname);
 #endif
 		}

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -1191,6 +1191,7 @@ void feh_draw_exif(winwidget w)
 				info_buf[i], IMLIB_TEXT_TO_RIGHT, 0, 0, 0, 255);
 		gib_imlib_text_draw(im, fn, NULL, 1, (i * line_height) + 1,
 				info_buf[i], IMLIB_TEXT_TO_RIGHT, 255, 255, 255, 255);
+		free(info_buf[i]);
 
 	}
 

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -290,6 +290,11 @@ int feh_is_image(feh_file * file)
 		// might be webp
 		return 1;
 	}
+	if (!memcmp(buf + 4, "ftyphei", 7) || !memcmp(buf + 4, "ftypmif1", 8)) {
+		// HEIC/HEIF - note that this is only supported in imlib2-heic. Ordinary
+		// imlib2 releases do not support heic/heif images as of 2021-01.
+		return 1;
+	}
 	buf[15] = 0;
 	if (strstr((char *)buf, "XPM")) {
 		// XPM

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -238,6 +238,7 @@ int feh_is_image(feh_file * file)
 		return 0;
 	}
 	if (fread(buf, 1, 16, fh) != 16) {
+		fclose(fh);
 		return 0;
 	}
 	fclose(fh);

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -383,7 +383,7 @@ int feh_load_image(Imlib_Image * im, feh_file * file)
 			// add_file_to_rm_filelist duplicates tmpname
 			add_file_to_rm_filelist(tmpname);
 
-		if (image_source != SRC_HTTP && !opt.use_conversion_cache)
+		if (!opt.use_conversion_cache)
 			free(tmpname);
 	} else if (im) {
 #ifdef HAVE_LIBEXIF

--- a/src/index.c
+++ b/src/index.c
@@ -332,7 +332,7 @@ void init_index_mode(void)
 
 		gib_imlib_save_image_with_error_return(im_main, output_buf, &err);
 		if (err) {
-			feh_imlib_print_load_error(output_buf, im_main, err);
+			feh_print_load_error(output_buf, im_main, err, LOAD_ERROR_IMLIB);
 		}
 		else if (opt.verbose) {
 			int tw, th;

--- a/src/menu.c
+++ b/src/menu.c
@@ -922,7 +922,12 @@ void feh_menu_init_main(void)
 	feh_menu_add_entry(m, "Reload", NULL, CB_RELOAD, 0, NULL);
 	feh_menu_add_entry(m, "Save Image", NULL, CB_SAVE_IMAGE, 0, NULL);
 	feh_menu_add_entry(m, "Save List", NULL, CB_SAVE_FILELIST, 0, NULL);
-	feh_menu_add_entry(m, "Edit in Place", "EDIT", 0, 0, NULL);
+	if (opt.edit) {
+		feh_menu_add_entry(m, "Edit in Place", "EDIT", 0, 0, NULL);
+	}
+	else {
+		feh_menu_add_entry(m, "Change View", "EDIT", 0, 0, NULL);
+	}
 	feh_menu_add_entry(m, "Background", "BACKGROUND", 0, 0, NULL);
 	feh_menu_add_entry(m, NULL, NULL, 0, 0, NULL);
 	feh_menu_add_entry(m, "Hide", NULL, CB_REMOVE, 0, NULL);

--- a/src/options.c
+++ b/src/options.c
@@ -835,7 +835,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 			opt.use_conversion_cache = 0;
 			break;
 		case 251:
-			opt.x11_windowid = atoi(optarg);
+			opt.x11_windowid = atol(optarg);
 			break;
 		default:
 			break;

--- a/src/options.c
+++ b/src/options.c
@@ -433,7 +433,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 #endif
 		{"class"         , 1, 0, 249},
 		{"no-conversion-cache", 0, 0, 250},
-		{"windowid", 1, 0, 251},
+		{"window-id", 1, 0, 251},
 		{0, 0, 0, 0}
 	};
 	int optch = 0, cmdx = 0;

--- a/src/options.h
+++ b/src/options.h
@@ -130,7 +130,7 @@ struct __fehoptions {
 	unsigned char adjust_reload;
 	int xinerama_index;
 	char *x11_class;
-	unsigned int *x11_windowid;
+	unsigned long int x11_windowid;
 
 	/* signed in case someone wants to invert scrolling real quick */
 	int scroll_step;

--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -225,6 +225,18 @@ void slideshow_change_image(winwidget winwid, int change, int render)
 	/* The for loop prevents us looping infinitely */
 	for (i = 0; i < our_filelist_len; i++) {
 		winwidget_free_image(winwid);
+#ifdef HAVE_LIBEXIF
+		/*
+		 * An EXIF data chunk requires up to 50 kB of space. For large and
+		 * long-running slideshows, this would acculumate gigabytes of
+		 * EXIF data after a few days. We therefore do not cache EXIF data
+		 * in slideshows.
+		 */
+		if (FEH_FILE(winwid->file->data)->ed) {
+			exif_data_unref(FEH_FILE(winwid->file->data)->ed);
+			FEH_FILE(winwid->file->data)->ed = NULL;
+		}
+#endif
 		switch (change) {
 		case SLIDE_NEXT:
 			current_file = feh_list_jump(filelist, current_file, FORWARD, 1);

--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -638,7 +638,7 @@ void slideshow_save_image(winwidget win)
 	gib_imlib_save_image_with_error_return(win->im, tmpname, &err);
 
 	if (err)
-		feh_imlib_print_load_error(tmpname, win, err);
+		feh_print_load_error(tmpname, win, err, LOAD_ERROR_IMLIB);
 
 	free(tmpname);
 	return;

--- a/src/thumbnail.c
+++ b/src/thumbnail.c
@@ -392,7 +392,7 @@ void init_thumbnail_mode(void)
 		}
 		gib_imlib_save_image_with_error_return(td.im_main, output_buf, &err);
 		if (err) {
-			feh_imlib_print_load_error(output_buf, td.im_main, err);
+			feh_print_load_error(output_buf, td.im_main, err, LOAD_ERROR_IMLIB);
 		}
 		else if (opt.verbose) {
 			int tw, th;

--- a/src/timers.c
+++ b/src/timers.c
@@ -58,7 +58,37 @@ double feh_get_time(void)
 	return((double) timev.tv_sec + (((double) timev.tv_usec) / 1000000));
 }
 
-void feh_remove_timer(char *name)
+void feh_remove_timer_by_data(void *data)
+{
+	fehtimer ft, ptr, pptr;
+
+	D(("removing timer for %p\n", data));
+	pptr = NULL;
+	ptr = first_timer;
+	while (ptr) {
+		D(("Stepping through event list\n"));
+		ft = ptr;
+		if (ft->data == data) {
+			D(("Found it. Removing\n"));
+			if (pptr)
+				pptr->next = ft->next;
+			else
+				first_timer = ft->next;
+			if (ft->next)
+				ft->next->in += ft->in;
+			if (ft->name)
+				free(ft->name);
+			if (ft)
+				free(ft);
+			return;
+		}
+		pptr = ptr;
+		ptr = ptr->next;
+	}
+	return;
+}
+
+static void feh_remove_timer(char *name)
 {
 	fehtimer ft, ptr, pptr;
 
@@ -87,6 +117,7 @@ void feh_remove_timer(char *name)
 	}
 	return;
 }
+
 
 void feh_add_timer(void (*func) (void *data), void *data, double in, char *name)
 {

--- a/src/timers.h
+++ b/src/timers.h
@@ -37,7 +37,7 @@ struct __fehtimer {
 
 void feh_handle_timer(void);
 double feh_get_time(void);
-void feh_remove_timer(char *name);
+void feh_remove_timer_by_data(void *data);
 void feh_add_timer(void (*func) (void *data), void *data, double in, char *name);
 void feh_add_unique_timer(void (*func) (void *data), void *data, double in);
 

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -29,6 +29,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "winwidget.h"
 #include "options.h"
 #include "events.h"
+#include "timers.h"
 
 #ifdef HAVE_INOTIFY
 #include <sys/inotify.h>
@@ -673,6 +674,9 @@ void winwidget_destroy(winwidget winwid)
 #ifdef HAVE_INOTIFY
     winwidget_inotify_remove(winwid);
 #endif
+	if (opt.reload > 0 && opt.multiwindow) {
+		feh_remove_timer_by_data(winwid);
+	}
 	winwidget_destroy_xwin(winwid);
 	if (winwid->name)
 		free(winwid->name);

--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -1014,8 +1014,9 @@ void winwidget_rename(winwidget winwid, char *newname)
 
 void winwidget_free_image(winwidget w)
 {
-	if (w->im)
+	if (w->im) {
 		gib_imlib_free_image(w->im);
+	}
 	w->im = NULL;
 	w->im_w = 0;
 	w->im_h = 0;

--- a/test/feh.t
+++ b/test/feh.t
@@ -47,7 +47,7 @@ if ( $version =~ m{ Compile-time \s switches : \s .* help }ox ) {
 }
 
 my $re_warning
-  = qr{${feh_name} WARNING: test/fail/... \- No Imlib2 loader for that file format\n};
+  = qr{${feh_name} WARNING: test/fail/... \- Does not look like an image \(magic bytes missing\)\n};
 my $re_loadable    = qr{test/ok/...};
 my $re_unloadable  = qr{test/fail/...};
 my $re_list_action = qr{test/ok/... 16x16};


### PR DESCRIPTION
Yet another `feh` option… This lets `feh` draw the background pixmap of an existing window, opening the door for use with tools like `xscreensaver` or `xsecurelock`

I opened this in response to #180, which was closed a long while ago but mentioned this functionality. I'm personally using this patch to display my wallpaper with `xsecurelock` for a seamless desktop/lock screen transition

This has always been one of my favorite pieces of software and I'm hoping the extra flag is justified for others to integrate it with their own setups! :tada: 