### PR TITLE
man: Silence mandoc warning.

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -585,7 +585,8 @@ When loading images via HTTP, ImageMagick or dcraw,
 .Nm
 will only load/convert them once and re-use the cached file on subsequent
 slideshow passes.
-This option disables the cache. It is also disabled when
+This option disables the cache.
+It is also disabled when
 .Cm --reload
 is used.
 Use it if you rely on frequently changing files loaded via one of these


### PR DESCRIPTION
This helps ensure the man implementation has consistent spacing between sentences.
```
feh.1:588:33: WARNING: new sentence, new line
```