### PR TITLE
Preserve Background and use Geometry Size from Options (bg-center)

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -1223,6 +1223,9 @@ Tile
 .Pq repeat
 the image in case it is too small for the screen
 .
+.It Cm --bg-preserve
+Combines the results of the addition of the new background with any possibly existing background.
+.
 .It Cm --no-fehbg
 .
 Do not write a

--- a/src/help.raw
+++ b/src/help.raw
@@ -82,6 +82,8 @@ OPTIONS
                            fill the whole background, but the images' aspect
                            ratio may not be preserved
      --bg-tile FILE        Set FILE as tiled desktop background
+     --bg-preserve         Combines the results of the addition of the new
+                           background with any possibly existing background.
      --no-fehbg            Do not write a ~/.fehbg file
  -C, --fontpath PATH       Specify an extra directory to look in for fonts,
                            can be used multiple times to add multiple paths.

--- a/src/options.c
+++ b/src/options.c
@@ -434,6 +434,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		{"class"         , 1, 0, 249},
 		{"no-conversion-cache", 0, 0, 250},
 		{"window-id", 1, 0, 251},
+		{"bg-preserve", 0, 0, 252},
 		{0, 0, 0, 0}
 	};
 	int optch = 0, cmdx = 0;
@@ -836,6 +837,9 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 			break;
 		case 251:
 			opt.x11_windowid = atol(optarg);
+			break;
+		case 252:
+			opt.bg_preserve = 1;
 			break;
 		default:
 			break;

--- a/src/options.h
+++ b/src/options.h
@@ -91,6 +91,7 @@ struct __fehoptions {
 	char *output_dir;
 	char *bg_file;
 	char *image_bg;
+	int bg_preserve;
 	char *font;
 	char *title_font;
 	char *title;

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -111,6 +111,13 @@ static void feh_wm_set_bg_centered(Pixmap pmap, Imlib_Image im, int use_filelist
 	img_w = gib_imlib_image_get_width(im);
 	img_h = gib_imlib_image_get_height(im);
 	if (opt.geom_w != 0 && opt.geom_h != 0) {
+		if (opt.geom_w == 0) {
+			double ratio = (double)img_w / (double)img_h;
+			opt.geom_w = (int) ((double)opt.geom_h * ratio);
+		} else if (opt.geom_h == 0) {
+			double ratio = (double)img_h / (double)img_w;
+			opt.geom_h = (int) ((double)opt.geom_w * ratio);
+		}
 
 		Imlib_Image im_old = im;
 		im = gib_imlib_create_cropped_scaled_image(im_old, 0, 0, img_w, img_h, opt.geom_w, opt.geom_h, 1);

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -103,25 +103,38 @@ static void feh_wm_set_bg_centered(Pixmap pmap, Imlib_Image im, int use_filelist
 		int x, int y, int w, int h)
 {
 	int offset_x, offset_y;
+	int img_w, img_h;
 
 	if (use_filelist)
 		feh_wm_load_next(&im);
 
+	img_w = gib_imlib_image_get_width(im);
+	img_h = gib_imlib_image_get_height(im);
+	if (opt.geom_w != 0 && opt.geom_h != 0) {
+
+		Imlib_Image im_old = im;
+		im = gib_imlib_create_cropped_scaled_image(im_old, 0, 0, img_w, img_h, opt.geom_w, opt.geom_h, 1);
+		gib_imlib_free_image_and_decache(im_old);
+
+		img_w = opt.geom_w;
+		img_h = opt.geom_h;
+	}
+
 	if(opt.geom_flags & XValue)
 		if(opt.geom_flags & XNegative)
-			offset_x = (w - gib_imlib_image_get_width(im)) + opt.geom_x;
+			offset_x = (w - img_w) + opt.geom_x;
 		else
 			offset_x = opt.geom_x;
 	else
-		offset_x = (w - gib_imlib_image_get_width(im)) >> 1;
+		offset_x = (w - img_w) >> 1;
 
 	if(opt.geom_flags & YValue)
 		if(opt.geom_flags & YNegative)
-			offset_y = (h - gib_imlib_image_get_height(im)) + opt.geom_y;
+			offset_y = (h - img_h) + opt.geom_y;
 		else
 			offset_y = opt.geom_y;
 	else
-		offset_y = (h - gib_imlib_image_get_height(im)) >> 1;
+		offset_y = (h - img_h) >> 1;
 
 	gib_imlib_render_image_part_on_drawable_at_size(pmap, im,
 		((offset_x < 0) ? -offset_x : 0),


### PR DESCRIPTION
Implemented preservation of existing backgrounds. Can be used to layer multiple `--bg-center` calls ontop of one another. (note. have a patch in development for other background calls)

Feh now uses XGeometry width and height to resize images for `--bg-center`. If width is zero and height is specified, width has its size determined from the aspect ratio of the image, and vice versa. However if width and height are both zero they are ignored.

*will add example from my branch*