### PR TITLE
Add --rotate=degrees, rotating each image degrees rightward after loading it

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -264,6 +264,14 @@ Automatic reload is not supported in montage, index, or thumbnail mode.
 Automatically rotate images based on EXIF data.
 Does not alter the image files.
 .
+.It Cm --rotate Ar 0 | Ar 90 | Ar 180 | Ar 270
+.
+Rotate each image
+.Ar degrees
+clockwise after loading it.
+.
+.Pp
+.
 .It Cm -Z , --auto-zoom
 .
 Zoom pictures to screen size in fullscreen / fixed geometry mode.

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -479,6 +479,8 @@ int feh_load_image(Imlib_Image * im, feh_file * file)
 		gib_imlib_image_orientate(*im, 3);
 #endif
 
+	gib_imlib_image_orientate(*im, opt.rotate);
+
 	D(("Loaded ok\n"));
 	return(1);
 }

--- a/src/options.c
+++ b/src/options.c
@@ -437,6 +437,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		{"class"         , 1, 0, OPTION_class},
 		{"no-conversion-cache", 0, 0, OPTION_no_conversion_cache},
 		{"window-id", 1, 0, OPTION_window_id},
+		{"rotate", 1, 0, OPTION_rotate},
 		{0, 0, 0, 0}
 	};
 	int optch = 0, cmdx = 0;
@@ -848,6 +849,9 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 			} else {
 				opt.zoom_rate = 1 + ((float)opt.zoom_rate / 100);
 			}
+			break;
+		case OPTION_rotate:
+			opt.rotate = atoi(optarg) / 90 % 4;
 			break;
 		default:
 			break;

--- a/src/options.h
+++ b/src/options.h
@@ -128,6 +128,7 @@ struct __fehoptions {
 	int default_zoom;
 	int zoom_mode;
 	double zoom_rate;
+	int rotate;
 	unsigned char adjust_reload;
 	int xinerama_index;
 	char *x11_class;
@@ -254,6 +255,7 @@ OPTION_auto_reload,
 OPTION_class,
 OPTION_no_conversion_cache,
 OPTION_window_id,
+OPTION_rotate,
 };
 
 //typedef enum __fehoption fehoption;


### PR DESCRIPTION
I recently ran into a use-case where rotating all images by defailt in a cardinal direxion would've been great, so here's that