### PR TITLE
Add JPEG XL to supported file formats

### DIFF
--- a/src/imlib.c
+++ b/src/imlib.c
@@ -312,6 +312,11 @@ int feh_is_image(feh_file * file)
 		// imlib2 releases do not support heic/heif images as of 2021-01.
 		return 1;
 	}
+	if ((buf[0] == 0xff && buf[1] == 0x0a) || !memcmp(buf, "\x00\x00\x00\x0cJXL \x0d\x0a\x87\x0a", 12)) {
+		// JXL - note that this is only supported in imlib2-jxl. Ordinary
+		// imlib2 releases do not support JXL images as of 2021-06.
+		return 1;
+	}
 	buf[15] = 0;
 	if (strstr((char *)buf, "XPM")) {
 		// XPM


### PR DESCRIPTION
Small change to make feh recognize the magic number for JPEG XL files (raw codestream or container) to avoid having to set FEH_SKIP_MAGIC when using imlib2-jxl (https://github.com/alistair7/imlib2-jxl).

This mimics the change for heic/heif as closely as possible.