### PR TITLE
Fix out of boundary access on illegal argument

### DIFF
--- a/src/filelist.c
+++ b/src/filelist.c
@@ -202,7 +202,7 @@ void add_file_to_filelist_recursively(char *origpath, unsigned char level)
 	struct stat st;
 	char *path;
 
-	if (!origpath)
+	if (!origpath || *origpath == '\0')
 		return;
 
 	path = estrdup(origpath);


### PR DESCRIPTION
Calling feh with an empty argument leads to out of boundary access.
This can be seen best when compiled with asan:

$ feh ""