### PR TITLE
Fix implicit definition of `strverscmp`.

### DIFF
--- a/src/filelist.c
+++ b/src/filelist.c
@@ -24,18 +24,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
-#ifdef HAVE_LIBEXIF
-#include <libexif/exif-data.h>
-#endif
-
-#ifdef HAVE_LIBCURL
-#include <curl/curl.h>
-#endif
-
 #include "feh.h"
 #include "filelist.h"
 #include "signals.h"
 #include "options.h"
+
+#ifdef HAVE_LIBCURL
+#include <curl/curl.h>
+#endif
 
 gib_list *filelist = NULL;
 gib_list *original_file_items = NULL; /* original file items from argv */


### PR DESCRIPTION
Gets rid of this warning:

```
filelist.c: In function ‘strcmp_or_strverscmp’:
filelist.c:414:10: warning: implicit declaration of function ‘strverscmp’; did you mean ‘strncmp’? [-Wimplicit-function-declaration]
  414 |   return(strverscmp(s1, s2));
      |          ^~~~~~~~~~
      |          strncmp
```