### PR TITLE
Add %T temp output filename format specifier

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -1327,6 +1327,10 @@ Human-readable image size
 .
 Image format
 .
+.It \&%T
+.
+Temporary output filename
+.
 .It %u
 .
 Number of current file

--- a/src/filelist.c
+++ b/src/filelist.c
@@ -49,6 +49,7 @@ feh_file *feh_file_new(char *filename)
 	newfile = (feh_file *) emalloc(sizeof(feh_file));
 	newfile->caption = NULL;
 	newfile->filename = estrdup(filename);
+	newfile->tempname = NULL;
 	s = strrchr(filename, '/');
 	if (s)
 		newfile->name = estrdup(s + 1);
@@ -67,6 +68,10 @@ void feh_file_free(feh_file * file)
 		return;
 	if (file->filename)
 		free(file->filename);
+	if (file->tempname) {
+		unlink(file->tempname);
+		free(file->tempname);
+	}
 	if (file->name)
 		free(file->name);
 	if (file->caption)

--- a/src/filelist.h
+++ b/src/filelist.h
@@ -32,6 +32,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 struct __feh_file {
 	char *filename;
+	char *tempname;
 	char *caption;
 	char *name;
 

--- a/src/help.raw
+++ b/src/help.raw
@@ -144,6 +144,7 @@ FORMAT SPECIFIERS
  %s     image size in bytes
  %S     image size with appropriate unit (kB/MB)
  %t     image format
+ %T     temporary output filename
  %u     current file number
  %w     image width
  %v     " PACKAGE " version

--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -511,6 +511,14 @@ char *feh_printf(char *str, feh_file * file, winwidget winwid)
 					strncat(ret, file->info->format, sizeof(ret) - strlen(ret) - 1);
 				}
 				break;
+			case 'T':
+				if (file) {
+					if (file->tempname == NULL) {
+						file->tempname = feh_unique_filename("/tmp/","feh_tempname");
+					}
+					strncat(ret, file->tempname, sizeof(ret) - strlen(ret) - 1);
+				}
+				break;
 			case 'u':
 				f = current_file ? current_file : gib_list_find_by_data(filelist, file);
 				snprintf(buf, sizeof(buf), "%d", f ? gib_list_num(filelist, f) + 1 : 0);


### PR DESCRIPTION
With the %T format specifier, one is able to supply an output file for an action's result.
Example usage:

feh --action ';[flatten]convert %F -layers flatten %T' myimage.gif

This will provide an action that flattens myimage.gif (shows all its layers), writing out the result in a temporary file (the %T invents a unique temporary filename).

This patch is working out great for me, but I understand if it has issues and is not quite good enough to merge.