### PR TITLE
use libmagic to detect valid file formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Dependencies
 
  * Imlib2
  * libcurl (disable with make curl=0)
+ * libmagic (disable with make magic=0)
  * libpng
  * libX11
  * libXinerama (disable with make xinerama=0)
@@ -91,6 +92,7 @@ indicates that the corresponding feature is enabled by default.
 | help | 0 | include help text (refers to the manpage otherwise) |
 | inotify | 0 | enable inotify, needed for `--auto-reload` |
 | stat64 | 0 | Support CIFS shares from 64bit hosts on 32bit machines |
+| magic | 1 | Build against libmagic to filter unsupported file formats |
 | mkstemps | 1 | Whether your libc provides `mkstemps()`. If set to 0, feh will be unable to load gif images via libcurl |
 | verscmp | 1 | Whether your libc provides `strvercmp()`. If set to 0, feh will use an internal implementation. |
 | xinerama | 1 | Support Xinerama/XRandR multiscreen setups |

--- a/config.mk
+++ b/config.mk
@@ -6,6 +6,7 @@ curl ?= 1
 debug ?= 0
 exif ?= 0
 help ?= 0
+magic ?= 1
 mkstemps ?= 1
 verscmp ?= 1
 xinerama ?= 1
@@ -66,6 +67,11 @@ endif
 
 ifeq (${mkstemps},1)
 	CFLAGS += -DHAVE_MKSTEMPS
+endif
+
+ifeq (${magic},1)
+	CFLAGS += -DHAVE_LIBMAGIC
+	LDLIBS += -lmagic
 endif
 
 ifeq (${verscmp},1)

--- a/src/feh.h
+++ b/src/feh.h
@@ -145,6 +145,10 @@ void init_slideshow_mode(void);
 void init_list_mode(void);
 void init_loadables_mode(void);
 void init_unloadables_mode(void);
+#ifdef HAVE_LIBMAGIC
+void uninit_magic(void);
+void init_magic(void);
+#endif
 void feh_clean_exit(void);
 int feh_should_ignore_image(Imlib_Image * im);
 int feh_load_image(Imlib_Image * im, feh_file * file);

--- a/src/main.c
+++ b/src/main.c
@@ -69,6 +69,10 @@ int main(int argc, char **argv)
 #endif
 	}
 
+#ifdef HAVE_LIBMAGIC
+	init_magic();
+#endif
+
 	feh_event_init();
 
 	if (opt.index)
@@ -261,6 +265,10 @@ void feh_clean_exit(void)
 
 	if(disp)
 		XCloseDisplay(disp);
+
+#ifdef HAVE_LIBMAGIC
+	uninit_magic();
+#endif
 
 	/*
 	 * Only restore the old terminal settings if

--- a/src/main.c
+++ b/src/main.c
@@ -49,6 +49,11 @@ int main(int argc, char **argv)
 	srandom(getpid() * time(NULL) % ((unsigned int) -1));
 
 	setup_signal_handlers();
+
+#ifdef HAVE_LIBMAGIC
+	init_magic();
+#endif
+
 	init_parse_options(argc, argv);
 
 	init_imlib_fonts();
@@ -68,10 +73,6 @@ int main(int argc, char **argv)
         }
 #endif
 	}
-
-#ifdef HAVE_LIBMAGIC
-	init_magic();
-#endif
 
 	feh_event_init();
 


### PR DESCRIPTION
Writing our own magic bytes detection is prone to errors and an
everlasting catch-up-game. Let's use libmagic to get things right,
this is less code and makes things more reliable.

Building without libmagic is still possible. That will make the code
act like specifying FEH_SKIP_MAGIC=1, effectively passing everything
to imlib2.