### PR TITLE
Set _DARWIN_C_SOURCE and include unistd.h

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -39,7 +39,7 @@ CFLAGS ?= -g -O2
 CFLAGS += -Wall -Wextra -pedantic
 
 # Settings for glibc >= 2.19 - may need to be adjusted for other systems
-CFLAGS += -std=c11 -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700
+CFLAGS += -std=c11 -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -D_DARWIN_C_SOURCE
 
 ifeq (${curl},1)
 	CFLAGS += -DHAVE_LIBCURL

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -35,6 +35,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <unistd.h>
 
 #ifdef HAVE_LIBCURL
 #include <curl/curl.h>


### PR DESCRIPTION
Building feh 3.8 fails on macOS 10.15.7 with Xcode 12.x with these errors:

```
imlib.c:729:7: error: implicit declaration of function 'mkdtemp' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                if (mkdtemp(tempdir) == NULL) {
                    ^
```
```
imlib.c:895:7: error: implicit declaration of function 'mkstemps' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        fd = mkstemps(sfn, strlen(basename) + 1);
             ^
```

(As of Xcode 12, implicit declaration of function is an error (as if `-Werror=implicit-function-declaration` were in CFLAGS). Apple did this in order to support Apple Silicon processors which have different calling conventions for variadic and non-variadic functions. The compiler must know, via the function prototype, what kind of function it is to generate the right machine code.)

This happens because in config.mk you define `_POSIX_C_SOURCE`. macOS responds by hiding some functions in the OS headers, including `mkdtemp` and `mkstemps`. To tell the OS you want these extensions, even though you requested POSIX mode, also define `_DARWIN_C_SOURCE`.

imlib.c uses `mkdtemp` and `mkstemps` (if told they are available) or `mkstemp` (if not). These are defined in unistd.h, so add that include to imlib.c. Although no build failure occurs without this include, that's presumably because some other system header that's being included includes unistd.h for us. Better to include it directly in case that changes.