### PR TITLE
Revert "Get geometry after mapping"

### DIFF
--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -851,8 +851,6 @@ void winwidget_show(winwidget winwid)
 		/* wait for the window to map */
 		D(("Waiting for window to map\n"));
 		XMaskEvent(disp, StructureNotifyMask, &ev);
-		winwidget_get_geometry(winwid, NULL);
-
 		/* Unfortunately, StructureNotifyMask does not only mask
 		 * the events of type MapNotify (which we want to mask here)
 		 * but also such of type ConfigureNotify (and others, see


### PR DESCRIPTION
This reverts commit 11eeb961f15219da506a050ffc432e052689dcd6.

It addresses the issue mentioned in #494, but it's not a proper fix in that the image still flickers once due to being positioned incorrectly at first (showing a checkered board on the left side) before eventually being moved into the correct location. Regardless, this behavior is much more favorable.

Disclaimer: I do not know enough about anything in this code to judge potential side-effects of reverting the commit.

Updates #494.