### PR TITLE
winwidget: do not add an inotify watch if file is a url

### DIFF
--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -739,7 +739,7 @@ void winwidget_inotify_remove(winwidget winwid)
 #ifdef HAVE_INOTIFY
 void winwidget_inotify_add(winwidget winwid, feh_file * file)
 {
-    if (opt.auto_reload) {
+    if (opt.auto_reload && !path_is_url(file->filename)) {
         D(("Adding inotify watch for %s\n", file->filename));
         char dir[PATH_MAX];
         feh_file_dirname(dir, file, PATH_MAX);


### PR DESCRIPTION
inotify_add_watch calls fail when the file is a url, since it does not
correspond to an actual on-disk path. The temporary file path fetched by
curl could be kept and monitored, but since this is unlikely to change
just avoid monitoring files opened via a url.