### PR TITLE
Fix horizontal gaps in montage mode

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -94,7 +94,11 @@ void init_index_mode(void)
 	text_area_h = fh + 5;
 
 	/* This includes the text area for index data */
-	tot_thumb_h = opt.thumb_h + text_area_h;
+	if(opt.montage) {
+		tot_thumb_h = opt.thumb_h;
+	} else {
+		tot_thumb_h = opt.thumb_h + text_area_h;
+	}
 
 	/* Use bg image dimensions for default size */
 	if (opt.bg && opt.bg_file) {

--- a/src/options.c
+++ b/src/options.c
@@ -633,6 +633,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 			break;
 		case OPTION_montage:
 			opt.index = 1;
+			opt.montage = 1;
 			break;
 		case OPTION_reverse:
 			opt.reverse = 1;


### PR DESCRIPTION
There are black horizontal 5px wide stripes between rows in montage mode. This happens because there are additional 5px added to height for index mode text.
```c
text_area_h = fh + 5;
tot_thumb_h = opt.thumb_h + text_area_h;
```
These gaps definitely shouldn't appear in montage mode as no text being printed there, and it makes usage of ```--limit-height``` flag hard because of 5px added every row.

Fixed by adding condition to add **text_area_h** to **tot_thumb_h** only in index mode.

Example with 4 separate images ```--thumb-width 256 --thumb-height 256 --limit-width 512```
Before:
![before](https://user-images.githubusercontent.com/52101866/189548793-aa8ab075-0945-4d9d-be84-c5086119f0d6.png)
After:
![after](https://user-images.githubusercontent.com/52101866/189548794-a5ab3198-be0c-46ae-b9b0-ce8c1ccbeb1e.png)
