### PR TITLE
Use `grep` instead of `fgrep`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build-applications:
 	@${MAKE} -C share/applications
 
 test: all
-	@if ! uname -m | fgrep -q -e arm -e mips; then \
+	@if ! uname -m | grep -q -e arm -e mips; then \
 		PACKAGE=${PACKAGE} prove test/feh.t test/mandoc.t; \
 	else \
 		PACKAGE=${PACKAGE} prove test/feh.t test/mandoc.t || cat test/imlib2-bug-notice; \


### PR DESCRIPTION
No need to use `grep -F` here, also silences a deprecation warning from latest GNU grep.