### PR TITLE
src: Fix build with clang 16

### DIFF
--- a/src/feh.h
+++ b/src/feh.h
@@ -160,7 +160,7 @@ void init_buttonbindings(void);
 void setup_stdin(void);
 void restore_stdin(void);
 void feh_event_handle_keypress(XEvent * ev);
-void feh_event_handle_stdin();
+void feh_event_handle_stdin(void);
 void feh_event_handle_generic(winwidget winwid, unsigned int state, KeySym keysym, unsigned int button);
 fehkey *feh_str_to_kb(char * action);
 void feh_action_run(feh_file * file, char *action, winwidget winwid);

--- a/src/filelist.c
+++ b/src/filelist.c
@@ -37,7 +37,6 @@ gib_list *filelist = NULL;
 gib_list *original_file_items = NULL; /* original file items from argv */
 int filelist_len = 0;
 gib_list *current_file = NULL;
-extern int errno;
 
 static gib_list *rm_filelist = NULL;
 
@@ -156,7 +155,7 @@ static void feh_print_stat_error(char *path)
 	}
 }
 
-static void add_stdin_to_filelist()
+static void add_stdin_to_filelist(void)
 {
 	char buf[1024];
 	size_t readsize;
@@ -657,7 +656,7 @@ char *feh_absolute_path(char *path)
 	return(ret);
 }
 
-void feh_save_filelist()
+void feh_save_filelist(void)
 {
 	char *tmpname;
 	char *base_dir = "";

--- a/src/filelist.h
+++ b/src/filelist.h
@@ -96,7 +96,7 @@ int feh_write_filelist(gib_list * list, char *filename);
 gib_list *feh_read_filelist(char *filename);
 char *feh_absolute_path(char *path);
 gib_list *feh_file_remove_from_list(gib_list * list, gib_list * l);
-void feh_save_filelist();
+void feh_save_filelist(void);
 char *feh_http_unescape(char * url);
 
 int feh_cmp_name(void *file1, void *file2);

--- a/src/gib_hash.c
+++ b/src/gib_hash.c
@@ -53,7 +53,7 @@ void           gib_hash_node_free_and_data(gib_hash_node *node)
 	return;
 }
 
-gib_hash *gib_hash_new()
+gib_hash *gib_hash_new(void)
 {
 	gib_hash *hash = emalloc(sizeof(gib_hash));
 	hash->base = gib_hash_node_new("__gib_hash_new",NULL);

--- a/src/gib_hash.h
+++ b/src/gib_hash.h
@@ -55,7 +55,7 @@ gib_hash_node *gib_hash_node_new(char *key, void *data);
 void           gib_hash_node_free(gib_hash_node *node);
 void           gib_hash_node_free_and_data(gib_hash_node *node);
 
-gib_hash *gib_hash_new();
+gib_hash *gib_hash_new(void);
 void      gib_hash_free(gib_hash *hash);
 void      gib_hash_free_and_data(gib_hash *hash);
 

--- a/src/keyevents.c
+++ b/src/keyevents.c
@@ -35,7 +35,7 @@ struct __fehkey keys[EVENT_LIST_END];
 struct termios old_term_settings;
 unsigned char control_via_stdin = 0;
 
-void setup_stdin() {
+void setup_stdin(void) {
 	struct termios ctrl;
 
 	control_via_stdin = 1;
@@ -55,7 +55,7 @@ void setup_stdin() {
 		eprintf("tcsetattr failed");
 }
 
-void restore_stdin() {
+void restore_stdin(void) {
 	if (tcsetattr(STDIN_FILENO, TCSANOW, &old_term_settings) == -1)
 		eprintf("tcsetattr failed");
 }
@@ -314,7 +314,7 @@ void feh_event_invoke_action(winwidget winwid, unsigned char action)
 	return;
 }
 
-void feh_event_handle_stdin()
+void feh_event_handle_stdin(void)
 {
 	char stdin_buf[2];
 	static char is_esc = 0;

--- a/src/menu.c
+++ b/src/menu.c
@@ -936,7 +936,7 @@ void feh_menu_init_main(void)
 	return;
 }
 
-void feh_menu_init_common()
+void feh_menu_init_common(void)
 {
 	int num_desks, i;
 	char buf[30];

--- a/src/signals.c
+++ b/src/signals.c
@@ -31,7 +31,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 void feh_handle_signal(int);
 volatile int sig_exit = 0;
 
-void setup_signal_handlers()
+void setup_signal_handlers(void)
 {
 	struct sigaction feh_sh;
 	sigset_t feh_ss;

--- a/src/signals.h
+++ b/src/signals.h
@@ -26,6 +26,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef SIGNALS_H
 #define SIGNALS_H
 
-void setup_signal_handlers();
+void setup_signal_handlers(void);
 extern volatile int sig_exit;
 #endif

--- a/src/thumbnail.c
+++ b/src/thumbnail.c
@@ -593,7 +593,7 @@ int feh_thumbnail_get_thumbnail(Imlib_Image * image, feh_file * file,
 	return status;
 }
 
-static char *feh_thumbnail_get_prefix()
+static char *feh_thumbnail_get_prefix(void)
 {
 	char *dir = NULL, *home, *xdg_cache_home;
 
@@ -882,13 +882,13 @@ void feh_thumbnail_select_prev(winwidget winwid, int jump)
 	}
 }
 
-void feh_thumbnail_show_selected()
+void feh_thumbnail_show_selected(void)
 {
 	if (td.selected && td.selected->file)
 		feh_thumbnail_show_fullsize(td.selected->file);
 }
 
-feh_file* feh_thumbnail_get_selected_file()
+feh_file* feh_thumbnail_get_selected_file(void)
 {
 	if (td.selected)
 		return td.selected->file;

--- a/src/thumbnail.h
+++ b/src/thumbnail.h
@@ -83,8 +83,8 @@ void feh_thumbnail_show_fullsize(feh_file *thumbfile);
 void feh_thumbnail_select(winwidget winwid, feh_thumbnail *thumbnail);
 void feh_thumbnail_select_next(winwidget winwid, int jump);
 void feh_thumbnail_select_prev(winwidget winwid, int jump);
-void feh_thumbnail_show_selected();
-feh_file *feh_thumbnail_get_selected_file();
+void feh_thumbnail_show_selected(void);
+feh_file *feh_thumbnail_get_selected_file(void);
 
 int feh_thumbnail_setup_thumbnail_dir(void);
 


### PR DESCRIPTION
These are no longer supported in upcoming clang versions.

warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]

Reference: https://archives.gentoo.org/gentoo-dev/message/dd9f2d3082b8b6f8dfbccb0639e6e240