### PR TITLE
Add support for simple tap zones

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -437,6 +437,10 @@ Specify
 as extra directory in which to search for fonts; can be used multiple times to
 add multiple paths.
 .
+.It Cm --tap-zones
+.
+Enable tap zones for previous/next file in slide show mode
+.
 .It Cm --force-aliasing
 .
 Disable anti-aliasing for zooming, background setting etc.

--- a/src/events.c
+++ b/src/events.c
@@ -366,9 +366,12 @@ static void feh_event_handle_ButtonRelease(XEvent * ev)
 		} else if (opt.mode == MODE_NEXT) {
 			opt.mode = MODE_NORMAL;
 			winwid->mode = MODE_NORMAL;
-			if (winwid->type == WIN_TYPE_SLIDESHOW)
-				slideshow_change_image(winwid, SLIDE_NEXT, 1);
-			else if (winwid->type == WIN_TYPE_THUMBNAIL) {
+			if (winwid->type == WIN_TYPE_SLIDESHOW) {
+				if (opt.tap_zones && ev->xbutton.x < winwid->w / 2)
+					slideshow_change_image(winwid, SLIDE_PREV, 1);
+				else
+					slideshow_change_image(winwid, SLIDE_NEXT, 1);
+			} else if (winwid->type == WIN_TYPE_THUMBNAIL) {
 				feh_file *thumbfile;
 				int x, y;
 

--- a/src/help.raw
+++ b/src/help.raw
@@ -62,6 +62,7 @@ OPTIONS
                            reloads image with \";\", switches to next otherwise
      --action[1-9]         Extra actions triggered by pressing keys <1>to <9>
  -G, --draw-actions        Show the defined actions in the image window
+     --tap-zones           Enable tap zones for previous/next file in slide show mode
      --force-aliasing      Disable antialiasing
  -m, --montage             Enable montage mode
  -i, --index               Create an index print of all images

--- a/src/options.c
+++ b/src/options.c
@@ -419,6 +419,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		{"no-xinerama"   , 0, 0, OPTION_no_xinerama},
 		{"draw-tinted"   , 0, 0, OPTION_draw_tinted},
 		{"info"          , 1, 0, OPTION_info},
+		{"tap-zones"     , 0, 0, OPTION_tap_zones},
 		{"force-aliasing", 0, 0, OPTION_force_aliasing},
 		{"no-fehbg"      , 0, 0, OPTION_no_fehbg},
 		{"keep-zoom-vp"  , 0, 0, OPTION_keep_zoom_vp},
@@ -782,6 +783,9 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 			} else {
 				opt.draw_info = 1;
 			}
+			break;
+		case OPTION_tap_zones:
+			opt.tap_zones = 1;
 			break;
 		case OPTION_force_aliasing:
 			opt.force_aliasing = 1;

--- a/src/options.h
+++ b/src/options.h
@@ -107,6 +107,7 @@ struct __fehoptions {
 	char *index_info;
 
 	int force_aliasing;
+	int tap_zones;
 	int thumb_w;
 	int thumb_h;
 	int limit_w;
@@ -239,6 +240,7 @@ OPTION_auto_rotate,
 OPTION_no_xinerama,
 OPTION_draw_tinted,
 OPTION_info,
+OPTION_tap_zones,
 OPTION_force_aliasing,
 OPTION_no_fehbg,
 OPTION_scroll_step,


### PR DESCRIPTION
I have implemented simple tap zones as described in derf/feh#726.

The tap zones can be activated with the newly introduced `--tap-zones` command line switch. They are disabled by default. So there is no change in the default behavior for feh. For now, I have only implemented tap zones for previous/next file actions.