### PR TITLE
Small error in man-page

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -994,7 +994,7 @@ when setting the wallpaper.
 .Pp
 .
 Use
-.Cm xrandr --listmonitor
+.Cm xrandr --listmonitors
 to determine how Xinerama monitor IDs map to screens/monitors in your setup.
 .
 .


### PR DESCRIPTION
There's a place, under BACKGROUND SETTING, where it says to use `xrandr --listmonitor` to determine how Xinerama monitor IDs map to screens etc. This should be `xrandr --listmonitors` with an 's' at the end.