### PR TITLE
cache stat(2) calls

### DIFF
--- a/src/filelist.h
+++ b/src/filelist.h
@@ -36,6 +36,8 @@ struct __feh_file {
 	char *name;
 
 	/* info stuff */
+	time_t mtime;
+	int size;
 	feh_file_info *info;	/* only set when needed */
 #ifdef HAVE_LIBEXIF
 	ExifData *ed;
@@ -45,7 +47,6 @@ struct __feh_file {
 struct __feh_file_info {
 	int width;
 	int height;
-	int size;
 	int pixels;
 	unsigned char has_alpha;
 	char *format;
@@ -71,11 +72,11 @@ enum sort_type {
 	SORT_NAME,
 	SORT_FILENAME,
 	SORT_DIRNAME,
+	SORT_SIZE, // everything after SORT_SIZE requires stat(2) information on the filelist
 	SORT_MTIME,
-	SORT_WIDTH,
+	SORT_WIDTH, // everything after SORT_WIDTH requires preloading the images in the filelist
 	SORT_HEIGHT,
 	SORT_PIXELS,
-	SORT_SIZE,
 	SORT_FORMAT
 };
 
@@ -88,7 +89,8 @@ int file_selector_all(const struct dirent *unused);
 void add_file_to_filelist_recursively(char *origpath, unsigned char level);
 void add_file_to_rm_filelist(char *file);
 void delete_rm_files(void);
-gib_list *feh_file_info_preload(gib_list * list);
+gib_list *feh_file_info_preload(gib_list * list, int load_images);
+int feh_file_stat(feh_file * file);
 int feh_file_info_load(feh_file * file, Imlib_Image im);
 void feh_file_dirname(char *dst, feh_file * f, int maxlen);
 void feh_prepare_filelist(void);

--- a/src/list.c
+++ b/src/list.c
@@ -50,7 +50,7 @@ void init_list_mode(void)
 					file->info->height,
 					format_size(file->info->pixels));
 			printf("\t%s\t%c\t%s\n",
-					format_size(file->info->size),
+					format_size(file->size),
 					file->info->has_alpha ? 'X' : '-', file->filename);
 		}
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -835,7 +835,7 @@ void feh_menu_draw_submenu_at(int x, int y, Imlib_Image dst, int ox, int oy)
 	for (int i= 0; i <= 3; i++) {
 	  imlib_image_draw_line(x+i, y+3+i, x+i, y+9-i, 0);
 	}
-	  
+
 	return;
 }
 
@@ -1401,7 +1401,7 @@ static feh_menu *feh_menu_func_gen_info(feh_menu * m)
 	if (!file->info)
 		feh_file_info_load(file, im);
 	if (file->info) {
-		snprintf(buffer, sizeof(buffer), "Size: %dKb", file->info->size / 1024);
+		snprintf(buffer, sizeof(buffer), "Size: %dKb", file->size / 1024);
 		feh_menu_add_entry(mm, buffer, NULL, 0, 0, NULL);
 		snprintf(buffer, sizeof(buffer), "Dimensions: %dx%d", file->info->width, file->info->height);
 		feh_menu_add_entry(mm, buffer, NULL, 0, 0, NULL);

--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -496,14 +496,14 @@ char *feh_printf(char *str, feh_file * file, winwidget winwid)
 				}
 				break;
 			case 's':
-				if (file && (file->info || !feh_file_info_load(file, NULL))) {
-					snprintf(buf, sizeof(buf), "%d", file->info->size);
+				if (file && (file->size >= 0 || !feh_file_stat(file))) {
+					snprintf(buf, sizeof(buf), "%d", file->size);
 					strncat(ret, buf, sizeof(ret) - strlen(ret) - 1);
 				}
 				break;
 			case 'S':
-				if (file && (file->info || !feh_file_info_load(file, NULL))) {
-					strncat(ret, format_size(file->info->size), sizeof(ret) - strlen(ret) - 1);
+				if (file && (file->size >= 0 || !feh_file_stat(file))) {
+					strncat(ret, format_size(file->size), sizeof(ret) - strlen(ret) - 1);
 				}
 				break;
 			case 't':


### PR DESCRIPTION
When the user requests sorting by size or mtime, do a "soft preload" of the file list that only calls stat(2) without loading images. This avoids calling stat(2) repeatedly on the same files when sorting the file list, and achieves faster startup on slow filesystems.

Closes https://github.com/derf/feh/issues/694