### PR TITLE
Fix incorrect zoom at init with `--scale-down` 

### DIFF
--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -860,8 +860,11 @@ void winwidget_show(winwidget winwid)
 		 * which should be handled, especially on tiling wm's. To
 		 * remedy this, the handler is executed explicitly:
 		 */
-		if (ev.type == ConfigureNotify)
+		if (ev.type == ConfigureNotify) {
+			winwid->w = -1; /* force render */
 			feh_event_handle_ConfigureNotify(&ev);
+		}
+
 		D(("Window mapped\n"));
 		winwid->visible = 1;
 	}


### PR DESCRIPTION
Hello. When using the `--scale-down` option, images render incorrectly at first on my setup (Xfce). After resizing feh, the image renders correctly. The following issues may be related:

https://github.com/derf/feh/issues/696
https://github.com/derf/feh/issues/504
https://github.com/derf/feh/issues/494

I don't have any experience with Xlib, but I did narrow it down to a race condition occurring between `winwidget_create_from_file` and `winwidget_show` here:

https://github.com/derf/feh/blob/70a7b06654217ae291659976fd8b8b4827ec379b/src/slideshow.c#L109-L111

For example, if I set a breakpoint on `winwidget_get_geometry` (which is invoked by both of the above functions) and simply continue on both breaks, the image renders properly.

The comment about `ConfigureNotify` in `winwidget_show` caught my eye, and I noticed that the `ConfigureNotify` handler was also invoked when resizing the window (which fixes rendering), except that it falls into this branch:

https://github.com/derf/feh/blob/70a7b06654217ae291659976fd8b8b4827ec379b/src/events.c#L432-L434

Forcing this to occur in `winwidget_show` by invalidating the width property seems to fix the issue. Obviously not ideal but this seems to be a painless workaround, at least on my setup, until there is a real fix.