### PR TITLE
(Experimental featrure) Suspending the X11 screen saver

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -10,6 +10,7 @@ magic ?= 0
 mkstemps ?= 1
 verscmp ?= 1
 xinerama ?= 1
+x11scrnsaver ?= 1
 
 # Prefix for all installed files
 PREFIX ?= /usr/local
@@ -87,6 +88,12 @@ ifeq (${xinerama},1)
 	MAN_XINERAMA = enabled
 else
 	MAN_XINERAMA = disabled
+endif
+
+ifeq (${x11scrnsaver},1)
+	CFLAGS += -DHAVE_X11SCRNSAVER
+	LDLIBS += -lXss
+else
 endif
 
 ifeq (${exif},1)

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -50,6 +50,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 magic_t magic = NULL;
 #endif
 
+#ifdef HAVE_X11SCRNSAVER
+#include <X11/extensions/scrnsaver.h>
+#endif
+
 Display *disp = NULL;
 Visual *vis = NULL;
 Screen *scr = NULL;
@@ -133,6 +137,10 @@ void init_x_and_imlib(void)
 #ifdef HAVE_LIBXINERAMA
 	init_xinerama();
 #endif				/* HAVE_LIBXINERAMA */
+
+#ifdef HAVE_X11SCRNSAVER
+	XScreenSaverSuspend(disp, True);
+#endif
 
 	imlib_context_set_display(disp);
 	imlib_context_set_visual(vis);


### PR DESCRIPTION
Expressing my appreciation for **feh** which has served me well over many years.

I don't at all consider this a bug fix.  Perhaps a feature proposal, or just for reference or discussion.

I was playing around with re-purposing a monitor and Raspberry Pi 3 as a photo frame.
This worked with feh out of the box (just worked, gotta love it) but by default the screen saver kicked in.
So I tried this programmatic change, and it does appear to suspend the X11 screen saver, as intended.

Happy to refactor this (if it's of broader interest) such as plumbing a CLI opt-in.