### PR TITLE
Use __func__ rather than __FUNCTION__ for C99 onwards

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -40,6 +40,16 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #ifdef DEBUG
 #ifdef __GNUC__
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */
+#define D(a) \
+{ \
+	if (opt.debug) { \
+		printf("%-12s +%-4u %-20s : ",__FILE__,__LINE__,__func__); \
+		printf a; \
+		fflush(stdout); \
+	} \
+  }
+#else
 #define D(a) \
 { \
 	if (opt.debug) { \
@@ -48,6 +58,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 		fflush(stdout); \
 	} \
   }
+#endif
 #else					/* __GNUC__ */
 #define D(a) \
 { \


### PR DESCRIPTION
In `make debug=1` mode for gcc 13.3.0, lots of warnings about the use of __FUNCTION__

```
debug.h:46:65: warning: ISO C does not support ‘__FUNCTION__’ predefined identifier [-Wpedantic]
   46 |                 printf("%-12s +%-4u %-20s : ",__FILE__,__LINE__,__FUNCTION__); \
      |                                                                 ^~~~~~~~~~~~
```

For C99 onwards, use [__func__](https://www.ibm.com/docs/en/i/7.5?topic=identifiers-func-predefined-identifier) instead.