### PR TITLE
Randomly Chosen Variable Time Delays for Slideshows

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -793,17 +793,26 @@ See
 for how to reverse it permanently.
 Default: 20
 .
-.It Cm -D , --slideshow-delay Ar float
+.It Cm -D , --slideshow-delay Ar float-list
 .
-For slideshow mode, wait
-.Ar float
-seconds between automatically changing slides.
-Useful for presentations.
-Specify a negative number to set the delay
-.Pq which will then be Ar float No * (-1) ,
-but start
+For slideshow mode, you can specify the delay between slide changes in seconds. 
+If multiple comma seperated delays are specified then these are used with equal 
+random probability. The list may contain duplicates. 
+If the list starts with a - (no decimal point) the display starts in paused mode. 
+A delay of 0 means perpetual delay (no timed slide changes) while a delay of 
+0.0 gives the least delay possible between slides.
+.
+As a shorthand you may also specify delays like this: 
+   --slideshow-delay 1.0x10,5x2,10
+.Pp
+This will give 10 times the probabiity of 1 second, twice the probability of 5 seconds as well as a single chance of a delay of 10 seconds. 
+The actual probabilities in this case being 10/13, 2/13 and 1/13 respectively. Real values as well as integers may be used for the multiplier.
+.Pp
+The Following would give the same as the above but starting 
 .Nm
 in paused mode.
+.
+   --slideshow-delay -1.0x10,5x2,10
 .
 .It Cm -S , --sort Ar sort_type
 .

--- a/src/help.raw
+++ b/src/help.raw
@@ -41,6 +41,8 @@ OPTIONS
      --auto-rotate         Rotate images according to Exif info (if compiled with exif=1)
  -^, --title TITLE         Set window title (see FORMAT SPECIFIERS)
  -D, --slideshow-delay NUM Set delay between automatically changing slides
+                           NUM,NUM,NUM or NUMxMult,NUMxMult also allowed,
+                           gives random delays equally or according to multipliers.
      --on-last-slide quit  Exit after one loop through the slide show (old --cycle-once)
      --on-last-slide hold  Stop at both ends of the filelist
  -R, --reload NUM          Reload images after NUM seconds

--- a/src/keyevents.c
+++ b/src/keyevents.c
@@ -699,7 +699,7 @@ void feh_event_handle_generic(winwidget winwid, unsigned int state, KeySym keysy
 			 * editing captions in slideshow mode does not make any sense
 			 * at all; this is just in case someone accidentally does it...
 			 */
-			if (opt.slideshow_delay)
+			if (opt.slideshow_delay==NULL)
 				opt.paused = 1;
 			winwid->caption_entry = 1;
 		}

--- a/src/options.c
+++ b/src/options.c
@@ -53,7 +53,7 @@ void init_parse_options(int argc, char **argv)
 	memset(&opt, 0, sizeof(fehoptions));
 	opt.display = 1;
 	opt.aspect = 1;
-	opt.slideshow_delay = 0.0;
+	opt.slideshow_delay = NULL;
 	opt.conversion_timeout = -1;
 	opt.thumb_w = 60;
 	opt.thumb_h = 60;
@@ -479,14 +479,25 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 			imlib_add_path_to_font_path(optarg);
 			break;
 		case OPTION_slideshow_delay:
-			opt.slideshow_delay = atof(optarg);
-			if (opt.slideshow_delay < 0.0) {
-				opt.slideshow_delay *= (-1);
-				opt.paused = 1;
-			} else {
-				opt.paused = 0;
-			}
-			break;
+            if (strcmp(optarg,"0")==0)
+            {
+              opt.slideshow_delay=realloc(opt.slideshow_delay,0);
+              opt.slideshow_delay=NULL;
+              opt.paused = 1;
+            }
+            else if (*optarg=='-')
+            {
+              opt.slideshow_delay=(char *) realloc(opt.slideshow_delay,strlen(optarg));
+              strcpy(opt.slideshow_delay,optarg+1);
+              opt.paused = 1;
+            }
+            else
+            {
+              opt.slideshow_delay=(char *) realloc(opt.slideshow_delay,strlen(optarg)+1);
+              strcpy(opt.slideshow_delay,optarg);
+              opt.paused = 0;
+            }
+            break;
 		case OPTION_thumb_height:
 			opt.thumb_h = atoi(optarg);
 			break;

--- a/src/options.h
+++ b/src/options.h
@@ -145,7 +145,7 @@ struct __fehoptions {
 	unsigned char mode;
 	unsigned char paused;
 
-	double slideshow_delay;
+	char *slideshow_delay;
 
 	signed int conversion_timeout;
 

--- a/test_file.txt
+++ b/test_file.txt
@@ -1,1 +1,0 @@
-test one

--- a/test_file.txt
+++ b/test_file.txt
@@ -1,0 +1,1 @@
+test one


### PR DESCRIPTION
This pull request adds some additional syntax to the -D option or --slideshow-delay option. 
The new code is fully backward compatible with the old syntax and definition of the -D option. 
The old syntax allowed a real number which gave the slide delay in seconds, with - to start in pauused mode and 0 meaning a perpetual delay.  For example
-D 10 
Would give a new slide every 10 seconds.

The syntax is extended in two way. First a comma seperated list of numbers may be used for example 
-D 5,10,20 
would give equal probability of delays of 5, 10 and 20 seconds. Duplicates are allowed so that 
-D 5,5,5,10,20 
would give 3 chances of a 5 second delay  and one of 10 seconds and one of 20. 

Each number may optionially include a multiplier so that the above can also be written: 
-D 5x3,10,20
As before a leading - is interpreted as start in paused mode. 