### PR TITLE
Add force-conversion option to skip imlib2 image loading and directly try to convert the image instead

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -173,6 +173,9 @@ digital cameras and similar.
 If the ImageMagick convert binary is available,
 .Nm
 will use it to load file types such as svg, xcf, and otf.
+Additionally
+.Cm --force-conversion
+can be used to skip the regular imlib2 image loading before trying to convert.
 .
 .Pp
 .
@@ -338,6 +341,15 @@ zero causes
 .Nm
 to try indefinitely.
 Negative values restore the default by disabling conversion altogether.
+.
+.It Cm --force-conversion
+.
+Force image conversion and skip the regular imlib2 image loading.
+If
+.Cm --conversion-timeout
+is not set or negative,
+.Cm --conversion-timeout
+will be set to zero.
 .
 .It Cm --class Ar class
 .

--- a/src/help.raw
+++ b/src/help.raw
@@ -98,6 +98,9 @@ OPTIONS
  -Y, --hide-pointer        Hide the pointer
      --conversion-timeout  INT  Load unknown files with dcraw or ImageMagick,
                            timeout after INT seconds (0: no timeout)
+     --force-conversion    Force image conversion and skip the regular imlib2
+                           image loading. Use conversion timeout of 0 if
+                           timeout is not set or negative.
      --min-dimension WxH   Only show images with width >= W and height >= H
      --max-dimension WxH   Only show images with width <= W and height <= H
      --scroll-step COUNT   scroll COUNT pixels when movement key is pressed

--- a/src/options.c
+++ b/src/options.c
@@ -430,6 +430,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		{"cache-size"    , 1, 0, OPTION_cache_size},
 		{"on-last-slide" , 1, 0, OPTION_on_last_slide},
 		{"conversion-timeout" , 1, 0, OPTION_conversion_timeout},
+		{"force-conversion" , 0, 0, OPTION_force_conversion},
 		{"version-sort"  , 0, 0, OPTION_version_sort},
 		{"offset"        , 1, 0, OPTION_offset},
 #ifdef HAVE_INOTIFY
@@ -829,6 +830,9 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 			break;
 		case OPTION_conversion_timeout:
 			opt.conversion_timeout = atoi(optarg);
+			break;
+		case OPTION_force_conversion:
+			opt.force_conversion = 1;
 			break;
 		case OPTION_version_sort:
 			opt.version_sort = 1;

--- a/src/options.h
+++ b/src/options.h
@@ -148,6 +148,7 @@ struct __fehoptions {
 	double slideshow_delay;
 
 	signed int conversion_timeout;
+	int force_conversion;
 
 	Imlib_Font menu_fn;
 };
@@ -250,6 +251,7 @@ OPTION_no_recursive,
 OPTION_cache_size,
 OPTION_on_last_slide,
 OPTION_conversion_timeout,
+OPTION_force_conversion,
 OPTION_version_sort,
 OPTION_offset,
 OPTION_auto_reload,


### PR DESCRIPTION
This PR adds the option `force-conversion` which skips the regular `imlib2` image loading before a conversion will be attempted.

This might be helpful in cases where `imlib2` is able to load the image but e.g. just a tiny thumbnail. This would prevent a further conversion, since the image was loaded successfully.

I faced this with `.NEF` raw files of a `Nikon Z7 II` camera.

With `force-conversion` enabled, `feh` will directly try to convert with `dcraw` or `image-magick`.

Since `force-conversion` only makes sense with enabled `image-conversion`, the latter option will be checked and set to zero if missing or negative.