### PR TITLE
Update imlib.c to explicitly include stdlib

### DIFF
--- a/src/imlib.c
+++ b/src/imlib.c
@@ -30,7 +30,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "winwidget.h"
 #include "options.h"
 
-#include <stdlib>
+#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -30,6 +30,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "winwidget.h"
 #include "options.h"
 
+#include <stdlib>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>


### PR DESCRIPTION
Fixes #791 
On slackware ARM64 version 15.0+ the compiler will Werror for mkstemps implicit declaration. I think it's just because mkstemps is not POSIX