### PR TITLE
Fix images not being centered when fully shown

### DIFF
--- a/src/winwidget.c
+++ b/src/winwidget.c
@@ -551,13 +551,13 @@ void winwidget_render_image(winwidget winwid, int resize, int force_alias)
 	dh = (winwid->h - winwid->im_y);
 	if (calc_w < dw) {
 		dw = calc_w;
-		if (!winwid->full_screen) {
+		if (dw >= winwid->w) {
 			dx = 0;
 		}
 	}
 	if (calc_h < dh) {
 		dh = calc_h;
-		if (!winwid->full_screen) {
+		if (dh >= winwid->h) {
 			dy = 0;
 		}
 	}


### PR DESCRIPTION
This broke with 2a90af6d3709dd01c447f18db5109cab86eb4735.

I don't know what that commit intended and thus cannot verify that it's still working as expected.

Fixes #795 and #796.