### PR TITLE
feat: add %K placeholder for key triggering action

### DIFF
--- a/src/feh.h
+++ b/src/feh.h
@@ -45,6 +45,17 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <X11/extensions/Xinerama.h>
 #include <X11/X.h>
 #endif				/* HAVE_LIBXINERAMA */
+
+/* Globals for passing key event info into actions (%k / %K in feh_printf) */
+extern KeySym feh_current_action_keysym;
+extern unsigned int feh_current_action_state;
+extern unsigned int feh_current_action_button;
+
+
+
+
+
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/keyevents.c
+++ b/src/keyevents.c
@@ -35,6 +35,11 @@ struct __fehkey keys[EVENT_LIST_END];
 struct termios old_term_settings;
 unsigned char control_via_stdin = 0;
 
+KeySym feh_current_action_keysym = 0;
+unsigned int feh_current_action_state = 0;
+unsigned int feh_current_action_button = 0;
+
+
 void setup_stdin(void) {
 	struct termios ctrl;
 
@@ -478,6 +483,11 @@ void feh_event_handle_generic(winwidget winwid, unsigned int state, KeySym keysy
 		return;
 	}
 
+	feh_current_action_keysym = keysym;
+	feh_current_action_state  = state;
+	feh_current_action_button = button;
+
+
 	if (feh_is_kp(EVENT_next_img, state, keysym, button)) {
 		if (opt.slideshow)
 			slideshow_change_image(winwid, SLIDE_NEXT, 1);
@@ -805,5 +815,12 @@ void feh_event_handle_generic(winwidget winwid, unsigned int state, KeySym keysy
 		}
 		winwidget_render_image(winwid, 1, 0);
 	}
+
+	feh_current_action_keysym = 0;
+	feh_current_action_state  = 0;
+	feh_current_action_button = 0;
+
+
+
 	return;
 }

--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -447,6 +447,37 @@ char *feh_printf(char *str, feh_file * file, winwidget winwid)
 					strncat(ret, buf, sizeof(ret) - strlen(ret) - 1);
 				}
 				break;
+
+			case 'k': {
+				if (feh_current_action_keysym) {
+					char *name = XKeysymToString(feh_current_action_keysym);
+					if (name)
+						strncat(ret, name, sizeof(ret) - strlen(ret) - 1);
+				}
+				break;
+			}
+			case 'K': {
+				char combo[64] = "";
+				if (feh_current_action_state & ControlMask)
+					strcat(combo, "C-");
+				if (feh_current_action_state & Mod1Mask)
+					strcat(combo, "M-");   // Alt
+				if (feh_current_action_state & ShiftMask)
+					strcat(combo, "S-");
+				if (feh_current_action_state & Mod4Mask)
+					strcat(combo, "Super-");
+
+				if (feh_current_action_keysym) {
+					char *name = XKeysymToString(feh_current_action_keysym);
+					if (name)
+						strncat(combo, name, sizeof(combo) - strlen(combo) - 1);
+				}
+
+				strncat(ret, combo, sizeof(ret) - strlen(ret) - 1);
+				break;
+			}
+
+
 			case 'l':
 				snprintf(buf, sizeof(buf), "%d", gib_list_length(filelist));
 				strncat(ret, buf, sizeof(ret) - strlen(ret) - 1);


### PR DESCRIPTION
- Introduced global variables to capture last key event (state, keysym, button)
- Extended feh_printf to expand %K with the actual key pressed
- Updated keyevents.c to assign globals before action handling
- this so downstream actions could be branced on pressed key not be limited to 10 actions only


This PR introduces a new printf-style substitution `%K` that expands
to the key (or key combination) which triggered the action.

### Motivation
Currently, feh actions can access file paths (`%f`, `%F`) and other
contextual info, but not the actual key used. This makes it harder
to write key-dependent custom scripts.

### Changes
- Added global vars in `feh.h` to store the last key event.
- Updated `keyevents.c` to populate these vars in `feh_event_handle_generic`.
- Extended `feh_printf` in `slideshow.c` to substitute `%K` with
  the triggering key sequence.
- Verified `%K` expands correctly for simple keys and combinations.

### Example usage
```bash
feh --action1 'echo "Pressed %K on %f"'

```

note:
most of this is llm generated for my use if any wants to have more actions than 10