### PR TITLE
Option to keep offset when switching file

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -423,6 +423,7 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 		{"force-aliasing", 0, 0, OPTION_force_aliasing},
 		{"no-fehbg"      , 0, 0, OPTION_no_fehbg},
 		{"keep-zoom-vp"  , 0, 0, OPTION_keep_zoom_vp},
+		{"keep-offset"   , 0, 0, OPTION_keep_offset},
 		{"scroll-step"   , 1, 0, OPTION_scroll_step},
 		{"xinerama-index", 1, 0, OPTION_xinerama_index},
 		{"insecure"      , 0, 0, OPTION_insecure},
@@ -795,6 +796,9 @@ static void feh_parse_option_array(int argc, char **argv, int finalrun)
 			break;
 		case OPTION_keep_zoom_vp:
 			opt.keep_zoom_vp = 1;
+			break;
+		case OPTION_keep_offset:
+			opt.keep_offset = 1;
 			break;
 		case OPTION_scroll_step:
 			opt.scroll_step = atoi(optarg);

--- a/src/options.h
+++ b/src/options.h
@@ -83,6 +83,7 @@ struct __fehoptions {
 	unsigned char text_bg;
 	unsigned char no_fehbg;
 	unsigned char keep_zoom_vp;
+	unsigned char keep_offset;
 	unsigned char insecure_ssl;
 	unsigned char filter_by_dimensions;
 	unsigned char edit;
@@ -221,6 +222,7 @@ OPTION_zoom_step,
 OPTION_zoom_in_rate,
 OPTION_zoom_out_rate,
 OPTION_keep_zoom_vp,
+OPTION_keep_offset,
 OPTION_no_screen_clip,
 OPTION_index_info,
 OPTION_magick_timeout,

--- a/src/slideshow.c
+++ b/src/slideshow.c
@@ -349,6 +349,10 @@ void slideshow_change_image(winwidget winwid, int change, int render)
 			winwidget_reset_image(winwid);
 			winwid->im_w = w;
 			winwid->im_h = h;
+			if(opt.keep_offset) {
+				winwid->im_x = opt.offset_x;
+				winwid->im_y = opt.offset_y;
+			}
 			if (render) {
 				winwidget_render_image(winwid, 1, 0);
 			}


### PR DESCRIPTION
I've added an option `--keep-offset` to preserve the forced offset (set by `--offset`) when switching to a next file in a slideshow

I was trying to adapt feh for use as a lightweight manga reader and images getting centered to the center of the page were preventing that use case.