### PR TITLE
menu: restore focus to feh window after hiding menu

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -514,6 +514,8 @@ void feh_menu_hide(feh_menu * m, int func_free)
 	if (m == menu_root) {
 		if (menu_cover) {
 			D(("DESTROYING menu cover\n"));
+			if (m->fehwin)
+				XSetInputFocus(disp, m->fehwin->win, RevertToPointerRoot, CurrentTime);
 			XDestroyWindow(disp, menu_cover);
 			menu_cover = 0;
 		}


### PR DESCRIPTION
focus was set to menu_cover on menu open but never restore on hide (say after performing a File->Delete); on Xwayland RevertToPointerRoot doesn't recover it; added an explicit call to XSetInputFocus back to fehwin->win before destroying the cover window.