### PR TITLE
add env variable for the .fehbg script

### DIFF
--- a/man/feh.pre
+++ b/man/feh.pre
@@ -1182,15 +1182,18 @@ In many desktop environments,
 can also be used as a background setter.
 Unless you pass the
 .Cm \-\-no\-fehbg
-option, it will write a script to set the current background to
-.Pa \[ti]/.fehbg .
+option, it will write a script to set the current background to the file
+specified by the
+.Ev FEH_FEHBG
+environment variable or
+.Pa \[ti]/.fehbg
+if it isn't set.
 So to have your background restored every time you start X, you can add
+for example
 .Qq \[ti]/.fehbg &
 to your X startup script
 .Pq such as Pa \[ti]/.xinitrc .
-Note that the commandline written to
-.Pa \[ti]/.fehbg
-always includes the
+Note that the commandline written to the script always includes the
 .Cm \-\-no\-fehbg
 option to ensure that it is not inadvertently changed by differences in
 X11 screen layout or similar.

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -250,9 +250,10 @@ static void feh_wm_set_bg_maxed(Pixmap pmap, Imlib_Image im, int use_filelist,
 ** as the last time the program was called.
 */
 void feh_wm_gen_bg_script(char* fil, int centered, int scaled, int filled, int use_filelist) {
-	char * home = getenv("HOME");
+	char *home = getenv("HOME");
+	char *custom_path = getenv("FEH_FEHBG");
 
-	if (!home)
+	if(!home && !custom_path)
 		return;
 
 	FILE *fp;
@@ -268,7 +269,10 @@ void feh_wm_gen_bg_script(char* fil, int centered, int scaled, int filled, int u
 	else
 		exec_method = cmdargv[0];
 
-	path = estrjoin("/", home, ".fehbg", NULL);
+	if(custom_path)
+		path = custom_path;
+	else
+		path = estrjoin("/", home, ".fehbg", NULL);
 
 	if ((fp = fopen(path, "w")) == NULL) {
 		weprintf("Can't write to %s", path);
@@ -339,7 +343,9 @@ void feh_wm_gen_bg_script(char* fil, int centered, int scaled, int filled, int u
 		}
 		fclose(fp);
 	}
-	free(path);
+
+	if(!custom_path)
+		free(path);
 
 	if(exec_method != cmdargv[0])
 		free(exec_method);


### PR DESCRIPTION
This simply gives the option to specify a the FEH_FEHBG environment variable for a custom ~/.fehbg script.
The manpage is also modified to reflect this change.