### PR TITLE
ci: update actions/checkout to v7

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -20,7 +20,7 @@ jobs:
         xinerama: [0, 1]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: APT
         run: sudo apt-get -y update
       - name: Install Dependencies

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -20,7 +20,7 @@ jobs:
         xinerama: [0, 1]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: APT
         run: sudo apt-get -y update
       - name: Install Dependencies


### PR DESCRIPTION
Updates the CI workflow to the current checkout major.

Changes:
- `actions/checkout@v2` updated to `actions/checkout@v7`

Validation:
- YAML syntax valid
- Workflow semantics unchanged (checkout only)

Scope: `.github/workflows/c.yml` only.